### PR TITLE
Check python output against our output for `Ok` variants

### DIFF
--- a/src/lenient_parse/internal/whitespace_block_tracker.gleam
+++ b/src/lenient_parse/internal/whitespace_block_tracker.gleam
@@ -1,8 +1,6 @@
 import gleam/int
 import lenient_parse/internal/tokenizer.{type Token, Whitespace}
 
-// TODO: Better name
-
 pub opaque type WhitespaceBlockTracker {
   WhitespaceBlockTracker(state: Int)
 }

--- a/test/check_against_python_test.gleam
+++ b/test/check_against_python_test.gleam
@@ -11,7 +11,7 @@ pub fn check_against_python_tests() {
   describe("check_against_python_tests", [
     describe(
       "python_float_test",
-      shared_test_data.float_data()
+      shared_test_data.float_data
         |> list.map(fn(test_data) {
           let input = test_data.input
           let input_printable_text = input |> helpers.to_printable_text
@@ -45,7 +45,7 @@ pub fn check_against_python_tests() {
     ),
     describe(
       "python_int_test",
-      shared_test_data.int_data()
+      shared_test_data.int_data
         |> list.map(fn(test_data) {
           let input = test_data.input
           let input_printable_text = input |> helpers.to_printable_text

--- a/test/check_against_python_test.gleam
+++ b/test/check_against_python_test.gleam
@@ -8,7 +8,6 @@ import shared_test_data
 import startest.{describe, it}
 import startest/expect
 
-// TODO: Refactor body
 pub fn check_against_python_tests() {
   describe("check_against_python_tests", [
     describe(

--- a/test/check_against_python_test.gleam
+++ b/test/check_against_python_test.gleam
@@ -5,46 +5,76 @@ import shared_test_data
 import startest.{describe, it}
 import startest/expect
 
+// TODO: Refactor body and panic message
+// TODO: Panic message should explain the issue
 pub fn check_against_python_tests() {
   describe("check_against_python_tests", [
     describe(
-      "expect_float_to_parse",
-      shared_test_data.valid_float_strings()
-        |> list.map(fn(input) {
-          let printable_text = input |> helpers.to_printable_text
-          use <- it("\"" <> printable_text <> "\"")
+      "python_float_test",
+      shared_test_data.float_data()
+        |> list.map(fn(test_data) {
+          let input = test_data.input
+          let input_printable_text = input |> helpers.to_printable_text
+          let output = test_data.output
+          let python_output = test_data.python_output
 
-          input |> python_parse.to_float |> expect.to_be_ok
+          let message = case output, python_output {
+            Ok(_), Ok(python_output) -> {
+              "should_coerce: \""
+              <> input_printable_text
+              <> "\" -> \""
+              <> python_output
+              <> "\""
+            }
+            Error(_), Error(_) -> {
+              "should_not_coerce: \""
+              <> input_printable_text
+              <> "\" -> \"Error\""
+            }
+            _, _ -> {
+              panic as "Invalid test data configuration - our coerce method and python's coerces method should both succeed or both fail for the same input."
+            }
+          }
+
+          use <- it(message)
+
+          input
+          |> python_parse.to_float
+          |> expect.to_equal(python_output)
         }),
     ),
     describe(
-      "expect_float_to_not_parse",
-      shared_test_data.invalid_float_strings()
-        |> list.map(fn(input) {
-          let printable_text = input |> helpers.to_printable_text
-          use <- it("\"" <> printable_text <> "\"")
+      "python_int_test",
+      shared_test_data.int_data()
+        |> list.map(fn(test_data) {
+          let input = test_data.input
+          let input_printable_text = input |> helpers.to_printable_text
+          let output = test_data.output
+          let python_output = test_data.python_output
 
-          input |> python_parse.to_float |> expect.to_be_error
-        }),
-    ),
-    describe(
-      "expect_int_to_parse",
-      shared_test_data.valid_int_strings()
-        |> list.map(fn(input) {
-          let printable_text = input |> helpers.to_printable_text
-          use <- it("\"" <> printable_text <> "\"")
+          let message = case output, python_output {
+            Ok(_), Ok(python_output) -> {
+              "should_coerce: \""
+              <> input_printable_text
+              <> "\" -> \""
+              <> python_output
+              <> "\""
+            }
+            Error(_), Error(_) -> {
+              "should_not_coerce: \""
+              <> input_printable_text
+              <> "\" -> \"Error\""
+            }
+            _, _ -> {
+              panic as "Invalid test data configuration - our coerce method and python's coerces method should both succeed or both fail for the same input."
+            }
+          }
 
-          input |> python_parse.to_int |> expect.to_be_ok
-        }),
-    ),
-    describe(
-      "expect_int_to_not_parse",
-      shared_test_data.invalid_int_strings()
-        |> list.map(fn(input) {
-          let printable_text = input |> helpers.to_printable_text
-          use <- it("\"" <> printable_text <> "\"")
+          use <- it(message)
 
-          input |> python_parse.to_int |> expect.to_be_error
+          input
+          |> python_parse.to_int
+          |> expect.to_equal(python_output)
         }),
     ),
   ])

--- a/test/check_against_python_test.gleam
+++ b/test/check_against_python_test.gleam
@@ -1,12 +1,14 @@
+import gleam/float
+import gleam/int
 import gleam/list
 import helpers
+import parse_error
 import python/python_parse
 import shared_test_data
 import startest.{describe, it}
 import startest/expect
 
-// TODO: Refactor body and panic message
-// TODO: Panic message should explain the issue
+// TODO: Refactor body
 pub fn check_against_python_tests() {
   describe("check_against_python_tests", [
     describe(
@@ -31,8 +33,19 @@ pub fn check_against_python_tests() {
               <> input_printable_text
               <> "\" -> \"Error\""
             }
-            _, _ -> {
-              panic as "Invalid test data configuration - our coerce method and python's coerces method should both succeed or both fail for the same input."
+            Ok(output), Error(_) -> {
+              panic as form_panic_message(
+                input_printable_text,
+                output |> float.to_string,
+                "Error",
+              )
+            }
+            Error(output), Ok(python_output) -> {
+              panic as form_panic_message(
+                input_printable_text,
+                output |> parse_error.to_string,
+                python_output,
+              )
             }
           }
 
@@ -65,8 +78,19 @@ pub fn check_against_python_tests() {
               <> input_printable_text
               <> "\" -> \"Error\""
             }
-            _, _ -> {
-              panic as "Invalid test data configuration - our coerce method and python's coerces method should both succeed or both fail for the same input."
+            Ok(output), Error(_) -> {
+              panic as form_panic_message(
+                input_printable_text,
+                output |> int.to_string,
+                "Error",
+              )
+            }
+            Error(output), Ok(python_output) -> {
+              panic as form_panic_message(
+                input_printable_text,
+                output |> parse_error.to_string,
+                python_output,
+              )
             }
           }
 
@@ -78,4 +102,20 @@ pub fn check_against_python_tests() {
         }),
     ),
   ])
+}
+
+fn form_panic_message(
+  input: String,
+  output: String,
+  python_output: String,
+) -> String {
+  "Invalid test data configuration."
+  <> " Test data for both our's and Python's coerce methods should both expect"
+  <> " to either succeed or fail for the same input.\n"
+  <> "Input: "
+  <> input
+  <> ", Output: "
+  <> output
+  <> ", Python Output: "
+  <> python_output
 }

--- a/test/python/python_parse.gleam
+++ b/test/python/python_parse.gleam
@@ -1,15 +1,15 @@
 import gleam/result
 import shellout
 
-pub fn to_float(text: String) -> Result(Nil, Nil) {
+pub fn to_float(text: String) -> Result(String, Nil) {
   text |> coerce("./test/python/parse_float.py")
 }
 
-pub fn to_int(text: String) -> Result(Nil, Nil) {
+pub fn to_int(text: String) -> Result(String, Nil) {
   text |> coerce("./test/python/parse_int.py")
 }
 
-fn coerce(text: String, program_path: String) -> Result(Nil, Nil) {
+fn coerce(text: String, program_path: String) -> Result(String, Nil) {
   shellout.command(
     run: "uv",
     with: [
@@ -24,6 +24,5 @@ fn coerce(text: String, program_path: String) -> Result(Nil, Nil) {
     in: ".",
     opt: [],
   )
-  |> result.replace(Nil)
   |> result.replace_error(Nil)
 }

--- a/test/shared_test_data.gleam
+++ b/test/shared_test_data.gleam
@@ -1,100 +1,415 @@
 import gleam/list
 import parse_error.{
-  EmptyString, InvalidCharacter, InvalidDecimalPosition,
-  InvalidUnderscorePosition, WhitespaceOnlyString,
+  type ParseError, EmptyString, InvalidCharacter, InvalidDecimalPosition,
+  InvalidSignPosition, InvalidUnderscorePosition, WhitespaceOnlyString,
 }
 
 // ---- float should coerce
 
-pub const valid_floats = [
-  #("1.001", 1.001), #("1.00", 1.0), #("1.0", 1.0), #("0.1", 0.1),
-  #("+1.0", 1.0), #("-1.0", -1.0), #("+123.321", 123.321),
-  #("-123.321", -123.321), #("1", 1.0), #("1.", 1.0), #(".1", 0.1),
-  #("1_000_000.0", 1_000_000.0), #("1_000_000.000_1", 1_000_000.0001),
-  #("1000.000_000", 1000.0), #("1", 1.0), #(" 1 ", 1.0), #(" 1.0 ", 1.0),
-  #(" 1000 ", 1000.0),
-]
-
-pub fn valid_float_strings() -> List(String) {
-  valid_floats |> list.map(fn(a) { a.0 })
+pub type FloatTestData {
+  FloatTestData(
+    input: String,
+    output: Result(Float, ParseError),
+    python_output: Result(String, Nil),
+  )
 }
+
+pub type IntegerTestData {
+  IntegerTestData(
+    input: String,
+    output: Result(Int, ParseError),
+    python_output: Result(String, Nil),
+  )
+}
+
+const valid_float_data = [
+  FloatTestData(input: "1.001", output: Ok(1.001), python_output: Ok("1.001")),
+  FloatTestData(input: "1.00", output: Ok(1.0), python_output: Ok("1.0")),
+  FloatTestData(input: "1.0", output: Ok(1.0), python_output: Ok("1.0")),
+  FloatTestData(input: "0.1", output: Ok(0.1), python_output: Ok("0.1")),
+  FloatTestData(input: "+1.0", output: Ok(1.0), python_output: Ok("1.0")),
+  FloatTestData(input: "-1.0", output: Ok(-1.0), python_output: Ok("-1.0")),
+  FloatTestData(
+    input: "+123.321",
+    output: Ok(123.321),
+    python_output: Ok("123.321"),
+  ),
+  FloatTestData(
+    input: "-123.321",
+    output: Ok(-123.321),
+    python_output: Ok("-123.321"),
+  ), FloatTestData(input: "1", output: Ok(1.0), python_output: Ok("1.0")),
+  FloatTestData(input: "1.", output: Ok(1.0), python_output: Ok("1.0")),
+  FloatTestData(input: ".1", output: Ok(0.1), python_output: Ok("0.1")),
+  FloatTestData(
+    input: "1_000_000.0",
+    output: Ok(1_000_000.0),
+    python_output: Ok("1000000.0"),
+  ),
+  FloatTestData(
+    input: "1_000_000.000_1",
+    output: Ok(1_000_000.0001),
+    python_output: Ok("1000000.0001"),
+  ),
+  FloatTestData(
+    input: "1000.000_000",
+    output: Ok(1000.0),
+    python_output: Ok("1000.0"),
+  ),
+  FloatTestData(
+    input: "1000.000_000",
+    output: Ok(1000.0),
+    python_output: Ok("1000.0"),
+  ), FloatTestData(input: " 1 ", output: Ok(1.0), python_output: Ok("1.0")),
+  FloatTestData(input: " 1.0 ", output: Ok(1.0), python_output: Ok("1.0")),
+  FloatTestData(
+    input: " 1000 ",
+    output: Ok(1000.0),
+    python_output: Ok("1000.0"),
+  ),
+]
 
 // ---- float should not coerce
 
-pub const invalid_float_assortment = [
-  #("", EmptyString), #(" ", WhitespaceOnlyString),
-  #("\t", WhitespaceOnlyString), #("\n", WhitespaceOnlyString),
-  #("\r", WhitespaceOnlyString), #("\f", WhitespaceOnlyString),
-  #(" \t\n\r\f ", WhitespaceOnlyString),
-  #("1_000__000.0", InvalidUnderscorePosition(6)),
-  #("..1", InvalidDecimalPosition(1)), #("1..", InvalidDecimalPosition(2)),
-  #(".1.", InvalidDecimalPosition(2)), #(".", InvalidDecimalPosition(0)),
-  #("", EmptyString), #(" ", WhitespaceOnlyString),
-  #("abc", InvalidCharacter("a", 0)),
+// TODO - sort these out into invalid catogories and remove this one
+const invalid_float_assortment_data = [
+  FloatTestData(
+    input: "",
+    output: Error(EmptyString),
+    python_output: Error(Nil),
+  ),
+  FloatTestData(
+    input: " ",
+    output: Error(WhitespaceOnlyString),
+    python_output: Error(Nil),
+  ),
+  FloatTestData(
+    input: "\t",
+    output: Error(WhitespaceOnlyString),
+    python_output: Error(Nil),
+  ),
+  FloatTestData(
+    input: "\n",
+    output: Error(WhitespaceOnlyString),
+    python_output: Error(Nil),
+  ),
+  FloatTestData(
+    input: "\r",
+    output: Error(WhitespaceOnlyString),
+    python_output: Error(Nil),
+  ),
+  FloatTestData(
+    input: "\f",
+    output: Error(WhitespaceOnlyString),
+    python_output: Error(Nil),
+  ),
+  FloatTestData(
+    input: "\r\n",
+    output: Error(WhitespaceOnlyString),
+    python_output: Error(Nil),
+  ),
+  FloatTestData(
+    input: " \t\n\r\f ",
+    output: Error(WhitespaceOnlyString),
+    python_output: Error(Nil),
+  ),
+  FloatTestData(
+    input: "1_000__000.0",
+    output: Error(InvalidUnderscorePosition(6)),
+    python_output: Error(Nil),
+  ),
+  FloatTestData(
+    input: "..1",
+    output: Error(InvalidDecimalPosition(1)),
+    python_output: Error(Nil),
+  ),
+  FloatTestData(
+    input: "1..",
+    output: Error(InvalidDecimalPosition(2)),
+    python_output: Error(Nil),
+  ),
+  FloatTestData(
+    input: ".1.",
+    output: Error(InvalidDecimalPosition(2)),
+    python_output: Error(Nil),
+  ),
+  FloatTestData(
+    input: ".",
+    output: Error(InvalidDecimalPosition(0)),
+    python_output: Error(Nil),
+  ),
+  FloatTestData(
+    input: "abc",
+    output: Error(InvalidCharacter("a", 0)),
+    python_output: Error(Nil),
+  ),
 ]
 
-pub const invalid_underscore_position_floats = [
-  #("1_.000", 1), #("1._000", 2), #("_1000.0", 0), #("1000.0_", 6),
-  #("1000._0", 5), #("1000_.0", 4), #("1000_.", 4),
+const invalid_underscore_position_float_data = [
+  FloatTestData(
+    input: "1_.000",
+    output: Error(InvalidUnderscorePosition(1)),
+    python_output: Error(Nil),
+  ),
+  FloatTestData(
+    input: "1._000",
+    output: Error(InvalidUnderscorePosition(2)),
+    python_output: Error(Nil),
+  ),
+  FloatTestData(
+    input: "_1000.0",
+    output: Error(InvalidUnderscorePosition(0)),
+    python_output: Error(Nil),
+  ),
+  FloatTestData(
+    input: "1000.0_",
+    output: Error(InvalidUnderscorePosition(6)),
+    python_output: Error(Nil),
+  ),
+  FloatTestData(
+    input: "1000._0",
+    output: Error(InvalidUnderscorePosition(5)),
+    python_output: Error(Nil),
+  ),
+  FloatTestData(
+    input: "1000_.0",
+    output: Error(InvalidUnderscorePosition(4)),
+    python_output: Error(Nil),
+  ),
+  FloatTestData(
+    input: "1000_.",
+    output: Error(InvalidUnderscorePosition(4)),
+    python_output: Error(Nil),
+  ),
 ]
 
-pub const invalid_character_position_floats = [#("100.00c01", "c", 6)]
+const invalid_character_position_float_data = [
+  FloatTestData(
+    input: "100.00c01",
+    output: Error(InvalidCharacter("c", 6)),
+    python_output: Error(Nil),
+  ),
+]
 
-pub fn invalid_float_strings() -> List(String) {
-  let a = invalid_float_assortment |> list.map(fn(a) { a.0 })
-  let b = invalid_underscore_position_floats |> list.map(fn(a) { a.0 })
-  let c = invalid_character_position_floats |> list.map(fn(a) { a.0 })
-  [a, b, c] |> list.flatten
+pub fn float_data() -> List(FloatTestData) {
+  [
+    valid_float_data,
+    invalid_float_assortment_data,
+    invalid_underscore_position_float_data,
+    invalid_character_position_float_data,
+  ]
+  |> list.flatten
 }
 
 // ---- int should coerce
 
-pub const valid_ints = [
-  #("1", 1), #("+123", 123), #(" +123 ", 123), #(" -123 ", -123), #("0123", 123),
-  #(" 0123", 123), #("-123", -123), #("1_000", 1000), #("1_000_000", 1_000_000),
-  #(" 1 ", 1),
+const valid_int_data = [
+  IntegerTestData(input: "1", output: Ok(1), python_output: Ok("1")),
+  IntegerTestData(input: "+123", output: Ok(123), python_output: Ok("123")),
+  IntegerTestData(input: " +123 ", output: Ok(123), python_output: Ok("123")),
+  IntegerTestData(input: " -123 ", output: Ok(-123), python_output: Ok("-123")),
+  IntegerTestData(input: "0123", output: Ok(123), python_output: Ok("123")),
+  IntegerTestData(input: " 0123", output: Ok(123), python_output: Ok("123")),
+  IntegerTestData(input: "-123", output: Ok(-123), python_output: Ok("-123")),
+  IntegerTestData(input: "1_000", output: Ok(1000), python_output: Ok("1000")),
+  IntegerTestData(
+    input: "1_000_000",
+    output: Ok(1_000_000),
+    python_output: Ok("1000000"),
+  ), IntegerTestData(input: " 1 ", output: Ok(1), python_output: Ok("1")),
 ]
-
-pub fn valid_int_strings() -> List(String) {
-  valid_ints |> list.map(fn(a) { a.0 })
-}
 
 // ---- int should not coerce
 
-pub const invalid_int_assortment = [
-  #("", EmptyString), #(" ", WhitespaceOnlyString),
-  #("\t", WhitespaceOnlyString), #("\n", WhitespaceOnlyString),
-  #("\r", WhitespaceOnlyString), #("\f", WhitespaceOnlyString),
-  #(" \t\n\r\f ", WhitespaceOnlyString),
-  #("1_000__000", InvalidUnderscorePosition(6)),
-  #("1.", InvalidDecimalPosition(1)), #("1.0", InvalidDecimalPosition(1)),
-  #("", EmptyString), #(" ", WhitespaceOnlyString),
-  #("abc", InvalidCharacter("a", 0)),
+// TODO - sort these out into invalid catogories and remove this one
+const invalid_int_assortment_data = [
+  IntegerTestData(
+    input: "",
+    output: Error(EmptyString),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: " ",
+    output: Error(WhitespaceOnlyString),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "\t",
+    output: Error(WhitespaceOnlyString),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "\n",
+    output: Error(WhitespaceOnlyString),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "\r",
+    output: Error(WhitespaceOnlyString),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "\f",
+    output: Error(WhitespaceOnlyString),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "\r\n",
+    output: Error(WhitespaceOnlyString),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: " \t\n\r\f\r\n ",
+    output: Error(WhitespaceOnlyString),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "1_000__000",
+    output: Error(InvalidUnderscorePosition(6)),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "1.",
+    output: Error(InvalidDecimalPosition(1)),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "1.0",
+    output: Error(InvalidDecimalPosition(1)),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "abc",
+    output: Error(InvalidCharacter("a", 0)),
+    python_output: Error(Nil),
+  ),
 ]
 
-pub const invalid_underscore_position_ints = [
-  #("_", 0), #("_1000", 0), #("1000_", 4), #(" _1000", 1), #("1000_ ", 4),
-  #("+_1000", 1), #("-_1000", 1), #("1__000", 2),
+const invalid_underscore_position_int_data = [
+  IntegerTestData(
+    input: "_",
+    output: Error(InvalidUnderscorePosition(0)),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "_1000",
+    output: Error(InvalidUnderscorePosition(0)),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "1000_",
+    output: Error(InvalidUnderscorePosition(4)),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: " _1000",
+    output: Error(InvalidUnderscorePosition(1)),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "1000_ ",
+    output: Error(InvalidUnderscorePosition(4)),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "+_1000",
+    output: Error(InvalidUnderscorePosition(1)),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "-_1000",
+    output: Error(InvalidUnderscorePosition(1)),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "1__000",
+    output: Error(InvalidUnderscorePosition(2)),
+    python_output: Error(Nil),
+  ),
 ]
 
-pub const invalid_character_position_ints = [
-  #("a", "a", 0), #("1b1", "b", 1), #("+ 1", " ", 1), #("1 1", " ", 1),
-  #(" 12 34 ", " ", 3),
+const invalid_character_position_int_data = [
+  IntegerTestData(
+    input: "a",
+    output: Error(InvalidCharacter("a", 0)),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "1b1",
+    output: Error(InvalidCharacter("b", 1)),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "+ 1",
+    output: Error(InvalidCharacter(" ", 1)),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "1 1",
+    output: Error(InvalidCharacter(" ", 1)),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: " 12 34 ",
+    output: Error(InvalidCharacter(" ", 3)),
+    python_output: Error(Nil),
+  ),
 ]
 
-pub const invalid_sign_position_ints = [
-  #("1+", "+", 1), #("1-", "-", 1), #("1+1", "+", 1), #("1-1", "-", 1),
+const invalid_sign_position_int_data = [
+  IntegerTestData(
+    input: "1+",
+    output: Error(InvalidSignPosition("+", 1)),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "1-",
+    output: Error(InvalidSignPosition("-", 1)),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "1+1",
+    output: Error(InvalidSignPosition("+", 1)),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "1-1",
+    output: Error(InvalidSignPosition("-", 1)),
+    python_output: Error(Nil),
+  ),
 ]
 
-pub const invalid_decimal_position_ints = [
-  #(".", 0), #("..", 0), #("0.0.", 1), #(".0.0", 0),
+const invalid_decimal_position_int_data = [
+  IntegerTestData(
+    input: ".",
+    output: Error(InvalidDecimalPosition(0)),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "..",
+    output: Error(InvalidDecimalPosition(0)),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "0.0.",
+    output: Error(InvalidDecimalPosition(1)),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: ".0.0",
+    output: Error(InvalidDecimalPosition(0)),
+    python_output: Error(Nil),
+  ),
 ]
 
-pub fn invalid_int_strings() -> List(String) {
-  let a = invalid_int_assortment |> list.map(fn(a) { a.0 })
-  let b = invalid_underscore_position_ints |> list.map(fn(a) { a.0 })
-  let c = invalid_character_position_ints |> list.map(fn(a) { a.0 })
-  let d = invalid_sign_position_ints |> list.map(fn(a) { a.0 })
-  let e = invalid_decimal_position_ints |> list.map(fn(a) { a.0 })
-  [a, b, c, d, e] |> list.flatten
+pub fn int_data() -> List(IntegerTestData) {
+  [
+    valid_int_data,
+    invalid_int_assortment_data,
+    invalid_underscore_position_int_data,
+    invalid_character_position_int_data,
+    invalid_sign_position_int_data,
+    invalid_decimal_position_int_data,
+  ]
+  |> list.flatten
 }

--- a/test/shared_test_data.gleam
+++ b/test/shared_test_data.gleam
@@ -1,4 +1,3 @@
-import gleam/list
 import parse_error.{
   type ParseError, EmptyString, InvalidCharacter, InvalidDecimalPosition,
   InvalidSignPosition, InvalidUnderscorePosition, WhitespaceOnlyString,
@@ -20,7 +19,7 @@ pub type IntegerTestData {
   )
 }
 
-const valid_float_data = [
+pub const float_data = [
   FloatTestData(input: "1.001", output: Ok(1.001), python_output: Ok("1.001")),
   FloatTestData(input: "1.00", output: Ok(1.0), python_output: Ok("1.0")),
   FloatTestData(input: "1.0", output: Ok(1.0), python_output: Ok("1.0")),
@@ -65,10 +64,6 @@ const valid_float_data = [
     output: Ok(1000.0),
     python_output: Ok("1000.0"),
   ),
-]
-
-// TODO - sort these out into invalid catogories and remove this one
-const invalid_float_assortment_data = [
   FloatTestData(
     input: "",
     output: Error(EmptyString),
@@ -110,11 +105,6 @@ const invalid_float_assortment_data = [
     python_output: Error(Nil),
   ),
   FloatTestData(
-    input: "1_000__000.0",
-    output: Error(InvalidUnderscorePosition(6)),
-    python_output: Error(Nil),
-  ),
-  FloatTestData(
     input: "..1",
     output: Error(InvalidDecimalPosition(1)),
     python_output: Error(Nil),
@@ -134,14 +124,6 @@ const invalid_float_assortment_data = [
     output: Error(InvalidDecimalPosition(0)),
     python_output: Error(Nil),
   ),
-  FloatTestData(
-    input: "abc",
-    output: Error(InvalidCharacter("a", 0)),
-    python_output: Error(Nil),
-  ),
-]
-
-const invalid_underscore_position_float_data = [
   FloatTestData(
     input: "1_.000",
     output: Error(InvalidUnderscorePosition(1)),
@@ -177,9 +159,16 @@ const invalid_underscore_position_float_data = [
     output: Error(InvalidUnderscorePosition(4)),
     python_output: Error(Nil),
   ),
-]
-
-const invalid_character_position_float_data = [
+  FloatTestData(
+    input: "1_000__000.0",
+    output: Error(InvalidUnderscorePosition(6)),
+    python_output: Error(Nil),
+  ),
+  FloatTestData(
+    input: "abc",
+    output: Error(InvalidCharacter("a", 0)),
+    python_output: Error(Nil),
+  ),
   FloatTestData(
     input: "100.00c01",
     output: Error(InvalidCharacter("c", 6)),
@@ -187,17 +176,7 @@ const invalid_character_position_float_data = [
   ),
 ]
 
-pub fn float_data() -> List(FloatTestData) {
-  [
-    valid_float_data,
-    invalid_float_assortment_data,
-    invalid_underscore_position_float_data,
-    invalid_character_position_float_data,
-  ]
-  |> list.flatten
-}
-
-const valid_int_data = [
+pub const int_data = [
   IntegerTestData(input: "1", output: Ok(1), python_output: Ok("1")),
   IntegerTestData(input: "+123", output: Ok(123), python_output: Ok("123")),
   IntegerTestData(input: " +123 ", output: Ok(123), python_output: Ok("123")),
@@ -211,10 +190,6 @@ const valid_int_data = [
     output: Ok(1_000_000),
     python_output: Ok("1000000"),
   ), IntegerTestData(input: " 1 ", output: Ok(1), python_output: Ok("1")),
-]
-
-// TODO - sort these out into invalid catogories and remove this one
-const invalid_int_assortment_data = [
   IntegerTestData(
     input: "",
     output: Error(EmptyString),
@@ -256,29 +231,6 @@ const invalid_int_assortment_data = [
     python_output: Error(Nil),
   ),
   IntegerTestData(
-    input: "1_000__000",
-    output: Error(InvalidUnderscorePosition(6)),
-    python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "1.",
-    output: Error(InvalidDecimalPosition(1)),
-    python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "1.0",
-    output: Error(InvalidDecimalPosition(1)),
-    python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "abc",
-    output: Error(InvalidCharacter("a", 0)),
-    python_output: Error(Nil),
-  ),
-]
-
-const invalid_underscore_position_int_data = [
-  IntegerTestData(
     input: "_",
     output: Error(InvalidUnderscorePosition(0)),
     python_output: Error(Nil),
@@ -318,9 +270,11 @@ const invalid_underscore_position_int_data = [
     output: Error(InvalidUnderscorePosition(2)),
     python_output: Error(Nil),
   ),
-]
-
-const invalid_character_position_int_data = [
+  IntegerTestData(
+    input: "1_000__000",
+    output: Error(InvalidUnderscorePosition(6)),
+    python_output: Error(Nil),
+  ),
   IntegerTestData(
     input: "a",
     output: Error(InvalidCharacter("a", 0)),
@@ -346,9 +300,11 @@ const invalid_character_position_int_data = [
     output: Error(InvalidCharacter(" ", 3)),
     python_output: Error(Nil),
   ),
-]
-
-const invalid_sign_position_int_data = [
+  IntegerTestData(
+    input: "abc",
+    output: Error(InvalidCharacter("a", 0)),
+    python_output: Error(Nil),
+  ),
   IntegerTestData(
     input: "1+",
     output: Error(InvalidSignPosition("+", 1)),
@@ -369,9 +325,6 @@ const invalid_sign_position_int_data = [
     output: Error(InvalidSignPosition("-", 1)),
     python_output: Error(Nil),
   ),
-]
-
-const invalid_decimal_position_int_data = [
   IntegerTestData(
     input: ".",
     output: Error(InvalidDecimalPosition(0)),
@@ -392,16 +345,14 @@ const invalid_decimal_position_int_data = [
     output: Error(InvalidDecimalPosition(0)),
     python_output: Error(Nil),
   ),
+  IntegerTestData(
+    input: "1.",
+    output: Error(InvalidDecimalPosition(1)),
+    python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "1.0",
+    output: Error(InvalidDecimalPosition(1)),
+    python_output: Error(Nil),
+  ),
 ]
-
-pub fn int_data() -> List(IntegerTestData) {
-  [
-    valid_int_data,
-    invalid_int_assortment_data,
-    invalid_underscore_position_int_data,
-    invalid_character_position_int_data,
-    invalid_sign_position_int_data,
-    invalid_decimal_position_int_data,
-  ]
-  |> list.flatten
-}

--- a/test/shared_test_data.gleam
+++ b/test/shared_test_data.gleam
@@ -4,8 +4,6 @@ import parse_error.{
   InvalidSignPosition, InvalidUnderscorePosition, WhitespaceOnlyString,
 }
 
-// ---- float should coerce
-
 pub type FloatTestData {
   FloatTestData(
     input: String,
@@ -68,8 +66,6 @@ const valid_float_data = [
     python_output: Ok("1000.0"),
   ),
 ]
-
-// ---- float should not coerce
 
 // TODO - sort these out into invalid catogories and remove this one
 const invalid_float_assortment_data = [
@@ -201,8 +197,6 @@ pub fn float_data() -> List(FloatTestData) {
   |> list.flatten
 }
 
-// ---- int should coerce
-
 const valid_int_data = [
   IntegerTestData(input: "1", output: Ok(1), python_output: Ok("1")),
   IntegerTestData(input: "+123", output: Ok(123), python_output: Ok("123")),
@@ -218,8 +212,6 @@ const valid_int_data = [
     python_output: Ok("1000000"),
   ), IntegerTestData(input: " 1 ", output: Ok(1), python_output: Ok("1")),
 ]
-
-// ---- int should not coerce
 
 // TODO - sort these out into invalid catogories and remove this one
 const invalid_int_assortment_data = [

--- a/test/to_float_parse_test.gleam
+++ b/test/to_float_parse_test.gleam
@@ -2,52 +2,45 @@ import gleam/float
 import gleam/list
 import helpers
 import lenient_parse
-import parse_error.{InvalidCharacter, InvalidUnderscorePosition}
+import parse_error
 import shared_test_data
 import startest.{describe, it}
 import startest/expect
 
+// TODO: Refactor body and panic message
+// TODO: Panic message should explain the issue
 pub fn coerce_into_valid_number_string_tests() {
-  describe("float_test", [
-    describe(
-      "should_coerce",
-      shared_test_data.valid_floats
-        |> list.map(fn(tuple) {
-          let #(input, output) = tuple
-          let output_string = output |> float.to_string
-          use <- it("\"" <> input <> "\" -> " <> output_string)
+  describe(
+    "float_test",
+    shared_test_data.float_data()
+      |> list.map(fn(test_data) {
+        let input = test_data.input
+        let input_printable_text = input |> helpers.to_printable_text
+        let output = test_data.output
 
-          input
-          |> lenient_parse.to_float
-          |> expect.to_equal(Ok(output))
-        }),
-    ),
-    describe(
-      "should_not_coerce",
-      [
-        shared_test_data.invalid_float_assortment,
-        shared_test_data.invalid_underscore_position_floats
-          |> list.map(fn(tuple) {
-            let #(input, index) = tuple
-            #(input, InvalidUnderscorePosition(index))
-          }),
-        shared_test_data.invalid_character_position_floats
-          |> list.map(fn(tuple) {
-            let #(input, invalid_character, index) = tuple
-            #(input, InvalidCharacter(invalid_character, index))
-          }),
-      ]
-        |> list.flatten
-        |> list.map(fn(tuple) {
-          let #(input, error) = tuple
-          let printable_text = input |> helpers.to_printable_text
-          let error_text = error |> parse_error.to_string
-          use <- it("\"" <> printable_text <> "\" -> " <> error_text)
+        let message = case output {
+          Ok(output) -> {
+            "should_coerce: \""
+            <> input_printable_text
+            <> "\" -> \""
+            <> output |> float.to_string
+            <> "\""
+          }
+          Error(error) -> {
+            let error_string = error |> parse_error.to_string
+            "should_not_coerce: \""
+            <> input_printable_text
+            <> "\" -> \""
+            <> error_string
+            <> "\""
+          }
+        }
 
-          input
-          |> lenient_parse.to_float
-          |> expect.to_equal(Error(error))
-        }),
-    ),
-  ])
+        use <- it(message)
+
+        input
+        |> lenient_parse.to_float
+        |> expect.to_equal(output)
+      }),
+  )
 }

--- a/test/to_float_parse_test.gleam
+++ b/test/to_float_parse_test.gleam
@@ -7,7 +7,6 @@ import shared_test_data
 import startest.{describe, it}
 import startest/expect
 
-// TODO: Refactor body
 pub fn coerce_into_valid_number_string_tests() {
   describe(
     "float_test",

--- a/test/to_float_parse_test.gleam
+++ b/test/to_float_parse_test.gleam
@@ -7,8 +7,7 @@ import shared_test_data
 import startest.{describe, it}
 import startest/expect
 
-// TODO: Refactor body and panic message
-// TODO: Panic message should explain the issue
+// TODO: Refactor body
 pub fn coerce_into_valid_number_string_tests() {
   describe(
     "float_test",

--- a/test/to_float_parse_test.gleam
+++ b/test/to_float_parse_test.gleam
@@ -12,7 +12,7 @@ import startest/expect
 pub fn coerce_into_valid_number_string_tests() {
   describe(
     "float_test",
-    shared_test_data.float_data()
+    shared_test_data.float_data
       |> list.map(fn(test_data) {
         let input = test_data.input
         let input_printable_text = input |> helpers.to_printable_text

--- a/test/to_int_parse_test.gleam
+++ b/test/to_int_parse_test.gleam
@@ -12,7 +12,7 @@ import startest/expect
 pub fn coerce_into_valid_number_string_tests() {
   describe(
     "int_test",
-    shared_test_data.int_data()
+    shared_test_data.int_data
       |> list.map(fn(test_data) {
         let input = test_data.input
         let input_printable_text = input |> helpers.to_printable_text

--- a/test/to_int_parse_test.gleam
+++ b/test/to_int_parse_test.gleam
@@ -2,65 +2,45 @@ import gleam/int
 import gleam/list
 import helpers
 import lenient_parse
-import parse_error.{
-  InvalidCharacter, InvalidDecimalPosition, InvalidSignPosition,
-  InvalidUnderscorePosition,
-}
+import parse_error
 import shared_test_data
 import startest.{describe, it}
 import startest/expect
 
+// TODO: Refactor body and panic message
+// TODO: Panic message should explain the issue
 pub fn coerce_into_valid_number_string_tests() {
-  describe("int_test", [
-    describe(
-      "should_coerce",
-      shared_test_data.valid_ints
-        |> list.map(fn(tuple) {
-          let #(input, output) = tuple
-          let output_string = output |> int.to_string
-          use <- it("\"" <> input <> "\" -> " <> output_string)
+  describe(
+    "int_test",
+    shared_test_data.int_data()
+      |> list.map(fn(test_data) {
+        let input = test_data.input
+        let input_printable_text = input |> helpers.to_printable_text
+        let output = test_data.output
 
-          input
-          |> lenient_parse.to_int
-          |> expect.to_equal(Ok(output))
-        }),
-    ),
-    describe(
-      "should_not_coerce",
-      [
-        shared_test_data.invalid_int_assortment,
-        shared_test_data.invalid_underscore_position_ints
-          |> list.map(fn(tuple) {
-            let #(input, index) = tuple
-            #(input, InvalidUnderscorePosition(index))
-          }),
-        shared_test_data.invalid_character_position_ints
-          |> list.map(fn(tuple) {
-            let #(input, invalid_character, index) = tuple
-            #(input, InvalidCharacter(invalid_character, index))
-          }),
-        shared_test_data.invalid_sign_position_ints
-          |> list.map(fn(tuple) {
-            let #(input, invalid_sign, index) = tuple
-            #(input, InvalidSignPosition(invalid_sign, index))
-          }),
-        shared_test_data.invalid_decimal_position_ints
-          |> list.map(fn(tuple) {
-            let #(input, index) = tuple
-            #(input, InvalidDecimalPosition(index))
-          }),
-      ]
-        |> list.flatten
-        |> list.map(fn(tuple) {
-          let #(input, error) = tuple
-          let printable_text = input |> helpers.to_printable_text
-          let error_text = error |> parse_error.to_string
-          use <- it("\"" <> printable_text <> "\" -> " <> error_text)
+        let message = case output {
+          Ok(output) -> {
+            "should_coerce: \""
+            <> input_printable_text
+            <> "\" -> \""
+            <> output |> int.to_string
+            <> "\""
+          }
+          Error(error) -> {
+            let error_string = error |> parse_error.to_string
+            "should_not_coerce: \""
+            <> input_printable_text
+            <> "\" -> \""
+            <> error_string
+            <> "\""
+          }
+        }
 
-          input
-          |> lenient_parse.to_int
-          |> expect.to_equal(Error(error))
-        }),
-    ),
-  ])
+        use <- it(message)
+
+        input
+        |> lenient_parse.to_int
+        |> expect.to_equal(output)
+      }),
+  )
 }

--- a/test/to_int_parse_test.gleam
+++ b/test/to_int_parse_test.gleam
@@ -7,7 +7,6 @@ import shared_test_data
 import startest.{describe, it}
 import startest/expect
 
-// TODO: Refactor body
 pub fn coerce_into_valid_number_string_tests() {
   describe(
     "int_test",

--- a/test/to_int_parse_test.gleam
+++ b/test/to_int_parse_test.gleam
@@ -7,8 +7,7 @@ import shared_test_data
 import startest.{describe, it}
 import startest/expect
 
-// TODO: Refactor body and panic message
-// TODO: Panic message should explain the issue
+// TODO: Refactor body
 pub fn coerce_into_valid_number_string_tests() {
   describe(
     "int_test",


### PR DESCRIPTION
Closes https://github.com/JosephTLyons/lenient_parse/issues/19

We can't interpret a Python result that is returned in the `Error` variants, as it is pure text over stderr. Even if we could, those errors would not map to ours. Therefore, we are only checking if the results match in the `Ok` variant, or if they are an error in general.

- [x] TODOs in the code on this branch