### PR TITLE
Update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,34 +16,32 @@ import lenient_parse
 import gleam/io
 
 pub fn main() {
-  "1" |> lenient_parse.to_float |> io.debug
+  // --- Float parsing
+
+  // Parse a string containing an integer
+  "1" |> to_float |> io.debug
   // Ok(1.0)
 
-  "1.001" |> lenient_parse.to_float |> io.debug
-  // Ok(1.001)
+  // Parse a string containing a negative float
+  "-5.001" |> to_float |> io.debug
+  // Ok(-5.001)
 
-  "+123.321" |> lenient_parse.to_float |> io.debug
-  // Ok(123.321)
+  // Parse a more complex float with scientific notation
+  "-1_234.567_8e-2" |> to_float |> io.debug
+  // -> Ok(-12.345678)
 
-  "-123.321" |> lenient_parse.to_float |> io.debug
-  // Ok(-123.321)
+  // --- Integer parsing
 
-  "1_000_000.0" |> lenient_parse.to_float |> io.debug
-  // Ok(1.0e6)
-
-  "4e3" |> lenient_parse.to_float |> io.debug
-  // Ok(4.0e3)
-
-  "123" |> lenient_parse.to_int |> io.debug
+  // Parse a string containing an integer
+  "123" |> to_int |> io.debug
   // Ok(123)
 
-  "+123" |> lenient_parse.to_int |> io.debug
-  // Ok(123)
-
-  "-123" |> lenient_parse.to_int |> io.debug
+  // Parse a string containing a negative integer with surrounding whitespace
+  "  -123  " |> to_int |> io.debug
   // Ok(-123)
 
-  "1_000_000" |> lenient_parse.to_int |> io.debug
+  // Parse a string containing an integer with an underscores
+  "1_000_000" |> to_int |> io.debug
   // Ok(1000000)
 }
 ```

--- a/src/lenient_parse.gleam
+++ b/src/lenient_parse.gleam
@@ -1,47 +1,16 @@
 import lenient_parse/internal/parse
 import parse_error.{type ParseError}
 
-/// Converts a string to a float using a more lenient parsing method than gleam's `float.parse()`. It behaves similarly to Python's `float()` built-in function.
-///
-/// ## Examples
-///
-/// ```gleam
-/// lenient_parse.to_float("1.001")           // -> Ok(1.001)
-/// lenient_parse.to_float("1")               // -> Ok(1.0)
-/// lenient_parse.to_float("1.")              // -> Ok(1.0)
-/// lenient_parse.to_float("1.0")             // -> Ok(1.0)
-/// lenient_parse.to_float(".1")              // -> Ok(0.1)
-/// lenient_parse.to_float("0.1")             // -> Ok(0.1)
-/// lenient_parse.to_float("+123.321")        // -> Ok(123.321)
-/// lenient_parse.to_float("-123.321")        // -> Ok(-123.321)
-/// lenient_parse.to_float(" 1.0 ")           // -> Ok(1.0)
-/// lenient_parse.to_float("1_000.0")         // -> Ok(1.0e3)
-/// lenient_parse.to_float("-1_234.567_8e-2") // -> Ok(-12.345678)
-/// lenient_parse.to_float("")                // -> Error(EmptyString)
-/// lenient_parse.to_float(" ")               // -> Error(WhitespaceOnlyString)
-/// lenient_parse.to_float("abc")             // -> Error(UnknownCharacter("a", 0))
-/// ```
+/// Converts a string to a float using a more lenient parsing method than
+/// gleam's `float.parse()`. It behaves similarly to Python's `float()` built-in
+/// function.
 pub fn to_float(text: String) -> Result(Float, ParseError) {
   text |> parse.parse_float
 }
 
-/// Converts a string to an integer using a more lenient parsing method than gleam's `int.parse()`.
-/// It behaves similarly to Python's `int()` built-in function.
-///
-/// ## Examples
-///
-/// ```gleam
-/// lenient_parse.to_int("123")   // -> Ok(123)
-/// lenient_parse.to_int("+123")  // -> Ok(123)
-/// lenient_parse.to_int("-123")  // -> Ok(-123)
-/// lenient_parse.to_int("0123")  // -> Ok(123)
-/// lenient_parse.to_int(" 123 ") // -> Ok(123)
-/// lenient_parse.to_int("1_000") // -> Ok(1000)
-/// lenient_parse.to_int("")      // -> Error(EmptyString)
-/// lenient_parse.to_int("1.0")   // -> Error(UnknownCharacter(".", 1))
-/// lenient_parse.to_int("abc")   // -> Error(UnknownCharacter("a", 0))
-/// lenient_parse.to_int("1E4")   // -> Error(UnknownCharacter("E", 1))
-/// ```
+/// Converts a string to an integer using a more lenient parsing method than
+/// gleam's `int.parse()`. It behaves similarly to Python's `int()` built-in
+/// function.
 pub fn to_int(text: String) -> Result(Int, ParseError) {
   text |> parse.parse_int
 }


### PR DESCRIPTION
Closes: #27 

These are hard to keep up to date. Let's remove all the doc string examples and only have examples in the README.md. Additionally, remove ones that don't show much variation.