### PR TITLE
Support inferred bases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.3.0 - XXXX-XX-XX
+
+- Added base 0 support to `lenient_parse.to_int_with_base`. WHen providing a base of 0, the function will automatically detect the base from the input string using the prefix (`0b`, `0o`, `0x`). If no prefix is found, the function will default to base 10.
+
 ## v1.2.0 - 2024-11-09
 
 - Added arbitrary base support for integer parsing - use pub `lenient_parse.to_int_with_base`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.3.0 - XXXX-XX-XX
 
-- Added base 0 support to `lenient_parse.to_int_with_base`. WHen providing a base of 0, the function will automatically detect the base from the input string using the prefix (`0b`, `0o`, `0x`). If no prefix is found, the function will default to base 10.
+- Added base 0 support to `lenient_parse.to_int_with_base`. When providing a base of 0, the function will look for a base prefix string (`0b`, `0o`, `0x`) to try to determine the base value. If no prefix is found, the function will default to base 10.
 
 ## v1.2.0 - 2024-11-09
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import gleam/io
 import lenient_parse
 
 pub fn main() {
-  // Parse a string containing an integer into a float
+  // Parse a string containing an integer value into a float
 
   "1" |> lenient_parse.to_float |> io.debug // Ok(1.0)
   "1" |> float.parse |> io.debug // Error(Nil)
@@ -33,12 +33,12 @@ pub fn main() {
   "-5.001" |> lenient_parse.to_float |> io.debug // Ok(-5.001)
   "-5.001" |> float.parse |> io.debug // Ok(-5.001)
 
-  // Parse a more complex float with scientific notation
+  // Parse a string containing a complex float with scientific notation
 
   "-1_234.567_8e-2" |> lenient_parse.to_float |> io.debug // Ok(-12.345678)
   "-1_234.567_8e-2" |> float.parse |> io.debug // Error(Nil)
 
-  // Parse a string containing an integer into an integer
+  // Parse a string containing an integer
 
   "123" |> lenient_parse.to_int |> io.debug // Ok(123)
   "123" |> int.parse |> io.debug // Ok(123)
@@ -53,15 +53,31 @@ pub fn main() {
   "1_000_000" |> lenient_parse.to_int |> io.debug // Ok(1000000)
   "1_000_000" |> int.parse |> io.debug // Error(Nil)
 
-  // Parse a binary string with underscores
+  // Parse a string containing a binary number with underscores
 
   "1000_0000" |> lenient_parse.to_int_with_base(base: 2) |> io.debug // Ok(128)
   "1000_0000" |> int.base_parse(2) |> io.debug // Error(Nil)
 
-  // Parse a hexadecimal string with underscores
+  // Parse a string containing a hexadecimal number with underscores
 
-  "DEAD_BEEF" |> lenient_parse.to_int_with_base(base: 16) |> io.debug// Ok(3735928559)
+  "DEAD_BEEF" |> lenient_parse.to_int_with_base(base: 16) |> io.debug // Ok(3735928559)
   "DEAD_BEEF" |> int.base_parse(16) |> io.debug // Error(Nil)
+
+  // Use base 0 to automatically detect the base when parsing strings with prefix indicators
+
+  "0b10" |> lenient_parse.to_int_with_base(base: 0) |> io.debug // Ok(2)
+  "0b10" |> int.base_parse(0) |> io.debug // Error(Nil)
+
+  "0o01234" |> lenient_parse.to_int_with_base(base: 0) |> io.debug // Ok(668)
+  "0o01234" |> int.base_parse(0) |> io.debug // Error(Nil)
+
+  "0xDEADBEEF" |> lenient_parse.to_int_with_base(base: 0) |> io.debug // Ok(3735928559)
+  "0xDEADBEEF" |> int.base_parse(0) |> io.debug // Error(Nil)
+
+  // If no prefix string is present, base 0 defaults to base 10
+
+  "-4" |> lenient_parse.to_int_with_base(base: 0) |> io.debug // Ok(-4)
+  "-4" |> int.base_parse(0) |> io.debug // Error(Nil)
 
   // Nice errors
 

--- a/src/lenient_parse.gleam
+++ b/src/lenient_parse.gleam
@@ -1,5 +1,5 @@
 import gleam/bool
-import lenient_parse/internal/base_constants.{base_10}
+import lenient_parse/internal/base_constants.{base_0, base_10}
 import lenient_parse/internal/parser
 import lenient_parse/internal/tokenizer
 import parse_error.{type ParseError, InvalidBaseValue}
@@ -26,7 +26,7 @@ pub fn to_int_with_base(
   text text: String,
   base base: Int,
 ) -> Result(Int, ParseError) {
-  let is_valid_base = base == 0 || { base >= 2 && base <= 36 }
+  let is_valid_base = base == base_0 || { base >= 2 && base <= 36 }
   use <- bool.guard(!is_valid_base, Error(InvalidBaseValue(base)))
   let tokens = text |> tokenizer.tokenize_int(base: base)
   tokens |> parser.parse_int(base: base)

--- a/src/lenient_parse.gleam
+++ b/src/lenient_parse.gleam
@@ -1,4 +1,5 @@
 import gleam/bool
+import lenient_parse/internal/base_constants.{base_10}
 import lenient_parse/internal/parser
 import lenient_parse/internal/tokenizer
 import parse_error.{type ParseError, InvalidBaseValue}
@@ -15,7 +16,7 @@ pub fn to_float(text text: String) -> Result(Float, ParseError) {
 /// gleam's `int.parse()`. It behaves similarly to Python's `int()` built-in
 /// function, using a default base of 10.
 pub fn to_int(text text: String) -> Result(Int, ParseError) {
-  text |> to_int_with_base(base: 10)
+  text |> to_int_with_base(base: base_10)
 }
 
 /// Converts a string to an integer using a more lenient parsing method than
@@ -25,7 +26,7 @@ pub fn to_int_with_base(
   text text: String,
   base base: Int,
 ) -> Result(Int, ParseError) {
-  let is_valid_base = base >= 2 && base <= 36
+  let is_valid_base = base == 0 || { base >= 2 && base <= 36 }
   use <- bool.guard(!is_valid_base, Error(InvalidBaseValue(base)))
   let tokens = text |> tokenizer.tokenize_int(base: base)
   tokens |> parser.parse_int(base: base)

--- a/src/lenient_parse/internal/base_constants.gleam
+++ b/src/lenient_parse/internal/base_constants.gleam
@@ -1,0 +1,7 @@
+pub const base_2 = 2
+
+pub const base_8 = 8
+
+pub const base_10 = 10
+
+pub const base_16 = 16

--- a/src/lenient_parse/internal/base_constants.gleam
+++ b/src/lenient_parse/internal/base_constants.gleam
@@ -1,3 +1,5 @@
+pub const base_0 = 0
+
 pub const base_2 = 2
 
 pub const base_8 = 8

--- a/src/lenient_parse/internal/parser.gleam
+++ b/src/lenient_parse/internal/parser.gleam
@@ -5,13 +5,14 @@ import gleam/option.{type Option, None, Some}
 import gleam/order
 import gleam/queue.{type Queue}
 import gleam/result
+import lenient_parse/internal/base_constants.{base_10}
 import lenient_parse/internal/scale
 import lenient_parse/internal/token.{
-  type Token, DecimalPoint, Digit, ExponentSymbol, Sign, Underscore, Unknown,
-  Whitespace,
+  type Token, BasePrefix, DecimalPoint, Digit, ExponentSymbol, Sign, Underscore,
+  Unknown, Whitespace,
 }
 import parse_error.{
-  type ParseError, EmptyString, InvalidDecimalPosition,
+  type ParseError, BasePrefixOnly, EmptyString, InvalidDecimalPosition,
   InvalidExponentSymbolPosition, InvalidUnderscorePosition, OutOfBaseRange,
   UnknownCharacter, WhitespaceOnlyString,
 }
@@ -29,14 +30,14 @@ pub fn parse_float(tokens tokens: List(Token)) -> Result(Float, ParseError) {
   let parse_data = parse_sign(tokens, next_index)
   use ParseData(is_positive, next_index, tokens) <- result.try(parse_data)
 
-  let parse_data = parse_digits(tokens, next_index)
+  let parse_data = parse_digits(tokens, next_index, base_10)
   use ParseData(whole_digits, next_index, tokens) <- result.try(parse_data)
 
   let parse_data = parse_decimal_point(tokens, next_index)
   use ParseData(decimal_specified, next_index, tokens) <- result.try(parse_data)
 
   let parse_data = case decimal_specified {
-    True -> parse_digits(tokens, next_index)
+    True -> parse_digits(tokens, next_index, base_10)
     False -> Ok(ParseData(queue.new(), next_index, tokens))
   }
   use ParseData(fractional_digits, next_index, tokens) <- result.try(parse_data)
@@ -53,7 +54,7 @@ pub fn parse_float(tokens tokens: List(Token)) -> Result(Float, ParseError) {
 
   let parse_data = case missing_digit_parts, exponent_symbol {
     True, Some(exponent_symbol) ->
-      Error(InvalidExponentSymbolPosition(exponent_symbol, next_index - 1))
+      Error(InvalidExponentSymbolPosition(next_index - 1, exponent_symbol))
     _, None -> Ok(ParseData(0, next_index, tokens))
     _, Some(exponent_symbol) -> {
       let parse_data = parse_sign(tokens, next_index)
@@ -61,14 +62,14 @@ pub fn parse_float(tokens tokens: List(Token)) -> Result(Float, ParseError) {
         parse_data,
       )
 
-      let parse_data = parse_digits(tokens, next_index)
+      let parse_data = parse_digits(tokens, next_index, base_10)
       use ParseData(exponent_digits, next_index, tokens) <- result.try(
         parse_data,
       )
 
       let parse_data = case exponent_digits |> queue.is_empty {
         True ->
-          Error(InvalidExponentSymbolPosition(exponent_symbol, next_index - 1))
+          Error(InvalidExponentSymbolPosition(next_index - 1, exponent_symbol))
         False -> Ok(ParseData(exponent_digits, next_index, tokens))
       }
       use ParseData(exponent_digits, next_index, tokens) <- result.try(
@@ -91,7 +92,7 @@ pub fn parse_float(tokens tokens: List(Token)) -> Result(Float, ParseError) {
 
   let remaining_token_result = case tokens {
     [] -> Ok(Nil)
-    [token, ..] -> Error(token.to_error(token))
+    [token, ..] -> Error(token.to_error(token, base_10))
   }
   use _ <- result.try(remaining_token_result)
 
@@ -120,7 +121,35 @@ pub fn parse_int(
   let parse_data = parse_sign(tokens, next_index)
   use ParseData(is_positive, next_index, tokens) <- result.try(parse_data)
 
-  let parse_data = parse_digits(tokens, next_index)
+  let parse_data = case base {
+    a if a == 0 || a == 2 || a == 8 || a == 16 -> {
+      let parse_data = parse_base_prefix(tokens, next_index)
+      use ParseData(base_data, next_index, tokens) <- result.try(parse_data)
+
+      let #(base, prefix_data) = case base_data {
+        Some(#(index_range, prefix, base)) -> #(
+          base,
+          Some(#(index_range, prefix)),
+        )
+        None -> {
+          let default_base = case a {
+            0 -> base_10
+            _ -> a
+          }
+
+          #(default_base, None)
+        }
+      }
+
+      Ok(ParseData(#(base, prefix_data), next_index, tokens))
+    }
+    _ -> Ok(ParseData(#(base, None), next_index, tokens))
+  }
+  use ParseData(#(base, prefix_data), next_index, tokens) <- result.try(
+    parse_data,
+  )
+
+  let parse_data = parse_digits(tokens, next_index, base)
   use ParseData(digits, next_index, tokens) <- result.try(parse_data)
 
   let parse_data = parse_whitespace(tokens, next_index)
@@ -128,14 +157,16 @@ pub fn parse_int(
 
   let remaining_token_result = case tokens {
     [] -> Ok(Nil)
-    [token, ..] -> Error(token.to_error(token))
+    [token, ..] -> Error(token.to_error(token, base))
   }
   use _ <- result.try(remaining_token_result)
 
-  case leading_whitespace, digits |> queue.is_empty {
-    None, True -> Error(EmptyString)
-    Some(_), True -> Error(WhitespaceOnlyString)
-    _, False -> {
+  case leading_whitespace, prefix_data, digits |> queue.is_empty {
+    None, None, True -> Error(EmptyString)
+    _, Some(#(index_range, prefix)), True ->
+      Error(BasePrefixOnly(index_range, prefix))
+    Some(_), _, True -> Error(WhitespaceOnlyString)
+    _, _, _ -> {
       let value = digits |> digits_to_int_with_base(base: base)
       let value = case is_positive {
         True -> value
@@ -160,7 +191,7 @@ fn do_parse_whitespace(
 ) -> Result(ParseData(Option(String)), ParseError) {
   case tokens {
     [Unknown(#(start_index, _), character), ..] ->
-      Error(UnknownCharacter(character, start_index))
+      Error(UnknownCharacter(start_index, character))
     [Whitespace(#(_, end_index), whitespace), ..rest] -> {
       do_parse_whitespace(
         tokens: rest,
@@ -185,12 +216,30 @@ fn parse_sign(
 ) -> Result(ParseData(Bool), ParseError) {
   case tokens {
     [Unknown(#(start_index, _), character), ..] ->
-      Error(UnknownCharacter(character, start_index))
+      Error(UnknownCharacter(start_index, character))
     [Sign(#(_, end_index), _, is_positive), ..rest] ->
       Ok(ParseData(data: is_positive, next_index: end_index, tokens: rest))
     _ -> {
       Ok(ParseData(data: True, next_index: index, tokens: tokens))
     }
+  }
+}
+
+fn parse_base_prefix(
+  tokens tokens: List(Token),
+  index index: Int,
+) -> Result(ParseData(Option(#(#(Int, Int), String, Int))), ParseError) {
+  case tokens {
+    [Unknown(#(start_index, _), character), ..] ->
+      Error(UnknownCharacter(start_index, character))
+    [BasePrefix(index_range, prefix, base), ..rest] -> {
+      Ok(ParseData(
+        data: Some(#(index_range, prefix, base)),
+        next_index: index_range.1,
+        tokens: rest,
+      ))
+    }
+    _ -> Ok(ParseData(data: None, next_index: index, tokens: tokens))
   }
 }
 
@@ -200,7 +249,7 @@ fn parse_decimal_point(
 ) -> Result(ParseData(Bool), ParseError) {
   case tokens {
     [Unknown(#(start_index, _), character), ..] ->
-      Error(UnknownCharacter(character, start_index))
+      Error(UnknownCharacter(start_index, character))
     [DecimalPoint(#(_, end_index)), ..rest] ->
       Ok(ParseData(data: True, next_index: end_index, tokens: rest))
     _ -> Ok(ParseData(data: False, next_index: index, tokens: tokens))
@@ -213,7 +262,7 @@ fn parse_exponent_symbol(
 ) -> Result(ParseData(Option(String)), ParseError) {
   case tokens {
     [Unknown(#(start_index, _), character), ..] ->
-      Error(UnknownCharacter(character, start_index))
+      Error(UnknownCharacter(start_index, character))
     [ExponentSymbol(#(_, end_index), exponent_symbol), ..rest] ->
       Ok(ParseData(
         data: Some(exponent_symbol),
@@ -227,10 +276,12 @@ fn parse_exponent_symbol(
 fn parse_digits(
   tokens tokens: List(Token),
   index index: Int,
+  base base: Int,
 ) -> Result(ParseData(Queue(Int)), ParseError) {
   do_parse_digits(
     tokens: tokens,
     index: index,
+    base: base,
     acc: queue.new(),
     at_beginning: True,
   )
@@ -239,18 +290,19 @@ fn parse_digits(
 fn do_parse_digits(
   tokens tokens: List(Token),
   index index: Int,
+  base base: Int,
   acc acc: Queue(Int),
   at_beginning at_beginning: Bool,
 ) -> Result(ParseData(Queue(Int)), ParseError) {
   case tokens {
     [Unknown(#(start_index, _), character), ..] ->
-      Error(UnknownCharacter(character, start_index))
+      Error(UnknownCharacter(start_index, character))
     [Whitespace(#(start_index, _), whitespace), ..] if at_beginning ->
-      Error(UnknownCharacter(whitespace, start_index))
+      Error(UnknownCharacter(start_index, whitespace))
     [Underscore(#(start_index, end_index)), ..rest] -> {
       let lookahead = rest |> list.first
       let at_end = case lookahead {
-        Ok(Digit(_, _, _, _)) -> False
+        Ok(Digit(_, _, _)) -> False
         _ -> True
       }
       let next_is_underscore = case lookahead {
@@ -271,20 +323,22 @@ fn do_parse_digits(
       do_parse_digits(
         tokens: rest,
         index: end_index,
+        base: base,
         acc: acc,
         at_beginning: False,
       )
     }
-    [Digit(#(_, end_index), _, value, base), ..rest] if value < base -> {
+    [Digit(#(_, end_index), _, value), ..rest] if value < base -> {
       do_parse_digits(
         tokens: rest,
         index: end_index,
+        base: base,
         acc: acc |> queue.push_back(value),
         at_beginning: False,
       )
     }
-    [Digit(#(start_index, _), character, value, base), ..] ->
-      Error(OutOfBaseRange(character, value, base, start_index))
+    [Digit(#(start_index, _), character, value), ..] ->
+      Error(OutOfBaseRange(start_index, character, value, base))
     _ -> Ok(ParseData(data: acc, next_index: index, tokens: tokens))
   }
 }
@@ -314,7 +368,7 @@ fn form_float(
 }
 
 fn digits_to_int(digits digits: Queue(Int)) -> Int {
-  digits_to_int_with_base(digits: digits, base: 10)
+  digits_to_int_with_base(digits: digits, base: base_10)
 }
 
 fn digits_to_int_with_base(digits digits: Queue(Int), base base: Int) -> Int {
@@ -345,8 +399,8 @@ fn do_power(
       }
     }
     order.Gt ->
-      do_power(base, exponent - 1, scale_factor * 10, exponent_is_positive)
+      do_power(base, exponent - 1, scale_factor * base_10, exponent_is_positive)
     order.Lt ->
-      do_power(base, exponent + 1, scale_factor * 10, exponent_is_positive)
+      do_power(base, exponent + 1, scale_factor * base_10, exponent_is_positive)
   }
 }

--- a/src/lenient_parse/internal/parser.gleam
+++ b/src/lenient_parse/internal/parser.gleam
@@ -5,7 +5,9 @@ import gleam/option.{type Option, None, Some}
 import gleam/order
 import gleam/queue.{type Queue}
 import gleam/result
-import lenient_parse/internal/base_constants.{base_10}
+import lenient_parse/internal/base_constants.{
+  base_0, base_10, base_16, base_2, base_8,
+}
 import lenient_parse/internal/scale
 import lenient_parse/internal/token.{
   type Token, BasePrefix, DecimalPoint, Digit, ExponentSymbol, Sign, Underscore,
@@ -122,7 +124,9 @@ pub fn parse_int(
   use ParseData(is_positive, next_index, tokens) <- result.try(parse_data)
 
   let parse_data = case base {
-    a if a == 0 || a == 2 || a == 8 || a == 16 -> {
+    base
+      if base == base_0 || base == base_2 || base == base_8 || base == base_16
+    -> {
       let parse_data = parse_base_prefix(tokens, next_index)
       use ParseData(base_data, next_index, tokens) <- result.try(parse_data)
 
@@ -132,9 +136,9 @@ pub fn parse_int(
           Some(#(index_range, prefix)),
         )
         None -> {
-          let default_base = case a {
+          let default_base = case base {
             0 -> base_10
-            _ -> a
+            _ -> base
           }
 
           #(default_base, None)

--- a/src/lenient_parse/internal/tokenizer.gleam
+++ b/src/lenient_parse/internal/tokenizer.gleam
@@ -1,7 +1,9 @@
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
-import lenient_parse/internal/base_constants.{base_10, base_16, base_2, base_8}
+import lenient_parse/internal/base_constants.{
+  base_0, base_10, base_16, base_2, base_8,
+}
 import lenient_parse/internal/token.{
   type Token, BasePrefix, DecimalPoint, Digit, ExponentSymbol, Sign, Underscore,
   Unknown, Whitespace,
@@ -60,15 +62,15 @@ fn do_tokenize_int(
         lookahead
       {
         False, "0", Ok(specifier)
-          if { base == 0 || base == 2 }
+          if { base == base_0 || base == base_2 }
           && { specifier == "b" || specifier == "B" }
         -> create_base_prefix(index, specifier, base_2, rest)
         False, "0", Ok(specifier)
-          if { base == 0 || base == 8 }
+          if { base == base_0 || base == base_8 }
           && { specifier == "o" || specifier == "O" }
         -> create_base_prefix(index, specifier, base_8, rest)
         False, "0", Ok(specifier)
-          if { base == 0 || base == 16 }
+          if { base == base_0 || base == base_16 }
           && { specifier == "x" || specifier == "X" }
         -> create_base_prefix(index, specifier, base_16, rest)
         _, _, _ -> {

--- a/src/lenient_parse/internal/tokenizer.gleam
+++ b/src/lenient_parse/internal/tokenizer.gleam
@@ -42,7 +42,6 @@ pub fn tokenize_int(text text: String, base base: Int) -> List(Token) {
   |> do_tokenize_int(base: base, index: 0, base_prefix_found: False, acc: [])
 }
 
-// TODO: clean up this logic, super WET
 fn do_tokenize_int(
   characters characters: List(String),
   base base: Int,
@@ -55,61 +54,25 @@ fn do_tokenize_int(
     [first, ..rest] -> {
       let lookahead = rest |> list.first
 
-      let a = case base_prefix_found, base, first, lookahead {
-        False, 0, "0", Ok(a) if a == "b" || a == "B" -> {
-          let token = BasePrefix(#(index, index + 2), "0" <> a, base_2)
-          let rest = case rest {
-            [] -> []
-            [_, ..rest] -> rest
-          }
-          Some(#(index + 2, token, rest, True))
-        }
-        False, 0, "0", Ok(a) if a == "o" || a == "O" -> {
-          let token = BasePrefix(#(index, index + 2), "0" <> a, base_8)
-          let rest = case rest {
-            [] -> []
-            [_, ..rest] -> rest
-          }
-          Some(#(index + 2, token, rest, True))
-        }
-        False, 0, "0", Ok(a) if a == "x" || a == "X" -> {
-          let token = BasePrefix(#(index, index + 2), "0" <> a, base_16)
-          let rest = case rest {
-            [] -> []
-            [_, ..rest] -> rest
-          }
-          Some(#(index + 2, token, rest, True))
-        }
-        False, 2, "0", Ok(a) if a == "b" || a == "B" -> {
-          let token = BasePrefix(#(index, index + 2), "0" <> a, base_2)
-          let rest = case rest {
-            [] -> []
-            [_, ..rest] -> rest
-          }
-          Some(#(index + 2, token, rest, True))
-        }
-        False, 8, "0", Ok(a) if a == "o" || a == "O" -> {
-          let token = BasePrefix(#(index, index + 2), "0" <> a, base_8)
-          let rest = case rest {
-            [] -> []
-            [_, ..rest] -> rest
-          }
-          Some(#(index + 2, token, rest, True))
-        }
-        False, 16, "0", Ok(a) if a == "x" || a == "X" -> {
-          let token = BasePrefix(#(index, index + 2), "0" <> a, base_16)
-          let rest = case rest {
-            [] -> []
-            [_, ..rest] -> rest
-          }
-          Some(#(index + 2, token, rest, True))
-        }
-        _, _, _, _ -> None
-      }
-
-      let #(index, token, rest, base_prefix_found) = case a {
-        Some(a) -> a
-        None -> {
+      let #(index, token, rest, base_prefix_found) = case
+        base_prefix_found,
+        base,
+        first,
+        lookahead
+      {
+        False, 0, "0", Ok(a) if a == "b" || a == "B" ->
+          create_base_prefix(index, a, base_2, rest)
+        False, 0, "0", Ok(a) if a == "o" || a == "O" ->
+          create_base_prefix(index, a, base_8, rest)
+        False, 0, "0", Ok(a) if a == "x" || a == "X" ->
+          create_base_prefix(index, a, base_16, rest)
+        False, 2, "0", Ok(a) if a == "b" || a == "B" ->
+          create_base_prefix(index, a, base_2, rest)
+        False, 8, "0", Ok(a) if a == "o" || a == "O" ->
+          create_base_prefix(index, a, base_8, rest)
+        False, 16, "0", Ok(a) if a == "x" || a == "X" ->
+          create_base_prefix(index, a, base_16, rest)
+        _, _, _, _ -> {
           let token =
             common_token(
               character: first,
@@ -130,6 +93,20 @@ fn do_tokenize_int(
       )
     }
   }
+}
+
+fn create_base_prefix(
+  index: Int,
+  specifier: String,
+  base: Int,
+  rest: List(String),
+) -> #(Int, Token, List(String), Bool) {
+  let token = BasePrefix(#(index, index + 2), "0" <> specifier, base)
+  let new_rest = case rest {
+    [] -> []
+    [_, ..rest] -> rest
+  }
+  #(index + 2, token, new_rest, True)
 }
 
 fn common_token(

--- a/src/lenient_parse/internal/tokenizer.gleam
+++ b/src/lenient_parse/internal/tokenizer.gleam
@@ -56,23 +56,22 @@ fn do_tokenize_int(
 
       let #(index, token, rest, base_prefix_found) = case
         base_prefix_found,
-        base,
         first,
         lookahead
       {
-        False, 0, "0", Ok(a) if a == "b" || a == "B" ->
-          create_base_prefix(index, a, base_2, rest)
-        False, 0, "0", Ok(a) if a == "o" || a == "O" ->
-          create_base_prefix(index, a, base_8, rest)
-        False, 0, "0", Ok(a) if a == "x" || a == "X" ->
-          create_base_prefix(index, a, base_16, rest)
-        False, 2, "0", Ok(a) if a == "b" || a == "B" ->
-          create_base_prefix(index, a, base_2, rest)
-        False, 8, "0", Ok(a) if a == "o" || a == "O" ->
-          create_base_prefix(index, a, base_8, rest)
-        False, 16, "0", Ok(a) if a == "x" || a == "X" ->
-          create_base_prefix(index, a, base_16, rest)
-        _, _, _, _ -> {
+        False, "0", Ok(specifier)
+          if { base == 0 || base == 2 }
+          && { specifier == "b" || specifier == "B" }
+        -> create_base_prefix(index, specifier, base_2, rest)
+        False, "0", Ok(specifier)
+          if { base == 0 || base == 8 }
+          && { specifier == "o" || specifier == "O" }
+        -> create_base_prefix(index, specifier, base_8, rest)
+        False, "0", Ok(specifier)
+          if { base == 0 || base == 16 }
+          && { specifier == "x" || specifier == "X" }
+        -> create_base_prefix(index, specifier, base_16, rest)
+        _, _, _ -> {
           let token =
             common_token(
               character: first,

--- a/src/lenient_parse/internal/tokenizer.gleam
+++ b/src/lenient_parse/internal/tokenizer.gleam
@@ -55,112 +55,61 @@ fn do_tokenize_int(
     [first, ..rest] -> {
       let lookahead = rest |> list.first
 
-      let #(index, token, rest, base_prefix_found) = case base {
-        0 -> {
-          case base_prefix_found, first, lookahead {
-            False, "0", Ok(a) if a == "b" || a == "B" -> {
-              let token = BasePrefix(#(index, index + 2), "0" <> a, base_2)
-              let rest = case rest {
-                [] -> []
-                [_, ..rest] -> rest
-              }
-              #(index + 2, token, rest, True)
-            }
-            False, "0", Ok(a) if a == "o" || a == "O" -> {
-              let token = BasePrefix(#(index, index + 2), "0" <> a, base_8)
-              let rest = case rest {
-                [] -> []
-                [_, ..rest] -> rest
-              }
-              #(index + 2, token, rest, True)
-            }
-            False, "0", Ok(a) if a == "x" || a == "X" -> {
-              let token = BasePrefix(#(index, index + 2), "0" <> a, base_16)
-              let rest = case rest {
-                [] -> []
-                [_, ..rest] -> rest
-              }
-              #(index + 2, token, rest, True)
-            }
-            _, _, _ -> {
-              let token =
-                common_token(
-                  character: first,
-                  index: index,
-                  tokenize_character_as_digit: fn(_) { True },
-                )
-
-              #(index + 1, token, rest, base_prefix_found)
-            }
+      let a = case base_prefix_found, base, first, lookahead {
+        False, 0, "0", Ok(a) if a == "b" || a == "B" -> {
+          let token = BasePrefix(#(index, index + 2), "0" <> a, base_2)
+          let rest = case rest {
+            [] -> []
+            [_, ..rest] -> rest
           }
+          Some(#(index + 2, token, rest, True))
         }
-        2 -> {
-          case base_prefix_found, first, lookahead {
-            False, "0", Ok(a) if a == "b" || a == "B" -> {
-              let token = BasePrefix(#(index, index + 2), "0" <> a, base_2)
-              let rest = case rest {
-                [] -> []
-                [_, ..rest] -> rest
-              }
-              #(index + 2, token, rest, True)
-            }
-            _, _, _ -> {
-              let token =
-                common_token(
-                  character: first,
-                  index: index,
-                  tokenize_character_as_digit: fn(_) { True },
-                )
-
-              #(index + 1, token, rest, base_prefix_found)
-            }
+        False, 0, "0", Ok(a) if a == "o" || a == "O" -> {
+          let token = BasePrefix(#(index, index + 2), "0" <> a, base_8)
+          let rest = case rest {
+            [] -> []
+            [_, ..rest] -> rest
           }
+          Some(#(index + 2, token, rest, True))
         }
-        8 -> {
-          case base_prefix_found, first, lookahead {
-            False, "0", Ok(a) if a == "o" || a == "O" -> {
-              let token = BasePrefix(#(index, index + 2), "0" <> a, base_8)
-              let rest = case rest {
-                [] -> []
-                [_, ..rest] -> rest
-              }
-              #(index + 2, token, rest, True)
-            }
-            _, _, _ -> {
-              let token =
-                common_token(
-                  character: first,
-                  index: index,
-                  tokenize_character_as_digit: fn(_) { True },
-                )
-
-              #(index + 1, token, rest, base_prefix_found)
-            }
+        False, 0, "0", Ok(a) if a == "x" || a == "X" -> {
+          let token = BasePrefix(#(index, index + 2), "0" <> a, base_16)
+          let rest = case rest {
+            [] -> []
+            [_, ..rest] -> rest
           }
+          Some(#(index + 2, token, rest, True))
         }
-        16 -> {
-          case base_prefix_found, first, lookahead {
-            False, "0", Ok(a) if a == "x" || a == "X" -> {
-              let token = BasePrefix(#(index, index + 2), "0" <> a, base_16)
-              let rest = case rest {
-                [] -> []
-                [_, ..rest] -> rest
-              }
-              #(index + 2, token, rest, True)
-            }
-            _, _, _ -> {
-              let token =
-                common_token(
-                  character: first,
-                  index: index,
-                  tokenize_character_as_digit: fn(_) { True },
-                )
-
-              #(index + 1, token, rest, base_prefix_found)
-            }
+        False, 2, "0", Ok(a) if a == "b" || a == "B" -> {
+          let token = BasePrefix(#(index, index + 2), "0" <> a, base_2)
+          let rest = case rest {
+            [] -> []
+            [_, ..rest] -> rest
           }
+          Some(#(index + 2, token, rest, True))
         }
-        _ -> {
+        False, 8, "0", Ok(a) if a == "o" || a == "O" -> {
+          let token = BasePrefix(#(index, index + 2), "0" <> a, base_8)
+          let rest = case rest {
+            [] -> []
+            [_, ..rest] -> rest
+          }
+          Some(#(index + 2, token, rest, True))
+        }
+        False, 16, "0", Ok(a) if a == "x" || a == "X" -> {
+          let token = BasePrefix(#(index, index + 2), "0" <> a, base_16)
+          let rest = case rest {
+            [] -> []
+            [_, ..rest] -> rest
+          }
+          Some(#(index + 2, token, rest, True))
+        }
+        _, _, _, _ -> None
+      }
+
+      let #(index, token, rest, base_prefix_found) = case a {
+        Some(a) -> a
+        None -> {
           let token =
             common_token(
               character: first,

--- a/src/parse_error.gleam
+++ b/src/parse_error.gleam
@@ -23,40 +23,47 @@ pub type ParseError {
   /// Represents an error when a sign (+ or -) is in an invalid position within
   /// the number string.
   ///
-  /// - `character`: The sign character that caused the error as a `String`.
   /// - `index`: The position of the invalid sign in the input string.
-  InvalidSignPosition(character: String, index: Int)
+  /// - `character`: The sign character that caused the error as a `String`.
+  InvalidSignPosition(index: Int, character: String)
 
   /// Represents an error when a digit is in an invalid position within the
   /// number string.
   ///
-  /// - `character`: The digit character that caused the error as a `String`.
   /// - `index`: The position of the invalid digit in the input string.
-  InvalidDigitPosition(character: String, index: Int)
+  /// - `character`: The digit character that caused the error as a `String`.
+  InvalidDigitPosition(index: Int, character: String)
+
+  /// Represents an error when the user specifies base = 0, but the input string
+  /// only contains a base prefix (`0b`, `0o`, 0x), and no value.
+  ///
+  /// - `index_range`: The position range of the prefix in the input string.
+  /// - `prefix`: The base prefix as a `String`.
+  BasePrefixOnly(index_range: #(Int, Int), prefix: String)
 
   /// Represents an error when a digit character is out of the valid range for
   /// the specified base.
   ///
+  /// - `index`: The position of the out-of-range digit in the input string.
   /// - `character`: The string representation of the out-of-range digit.
   /// - `value`: The integer value of the out-of-range digit.
   /// - `base`: The base in which the digit is out of range.
-  /// - `index`: The position of the out-of-range digit in the input string.
-  OutOfBaseRange(character: String, value: Int, base: Int, index: Int)
+  OutOfBaseRange(index: Int, character: String, value: Int, base: Int)
 
   /// Represents an error when an exponent symbol (e or E) is in an invalid
   /// position within the number string.
   ///
-  /// - `character`: The exponent symbol that caused the error as a `String`.
   /// - `index`: The position of the invalid exponent symbol in the input
   /// string.
-  InvalidExponentSymbolPosition(character: String, index: Int)
+  /// - `character`: The exponent symbol that caused the error as a `String`.
+  InvalidExponentSymbolPosition(index: Int, character: String)
 
   /// Represents an error when an invalid character is encountered during
   /// parsing.
   ///
-  /// - `character`: The invalid character as a `String`.
   /// - `index`: The position of the invalid character in the input string.
-  UnknownCharacter(character: String, index: Int)
+  /// - `character`: The invalid character as a `String`.
+  UnknownCharacter(index: Int, character: String)
 
   /// Represents an error when the base provided for parsing is invalid.
   ///
@@ -74,14 +81,21 @@ pub fn to_string(error: ParseError) -> String {
       "underscore at invalid position: " <> index |> int.to_string
     InvalidDecimalPosition(index) ->
       "decimal at invalid position: " <> index |> int.to_string
-    InvalidSignPosition(sign, index) ->
+    InvalidSignPosition(index, sign) ->
       "sign \"" <> sign <> "\" at invalid position: " <> index |> int.to_string
-    InvalidDigitPosition(digit, index) ->
+    InvalidDigitPosition(index, digit) ->
       "digit \""
       <> digit
       <> "\" at invalid position: "
       <> index |> int.to_string
-    OutOfBaseRange(character, value, base, index) ->
+    BasePrefixOnly(#(start_index, end_index), prefix) ->
+      "inferred base prefix only: "
+      <> prefix
+      <> " at index range: "
+      <> start_index |> int.to_string
+      <> ".."
+      <> end_index |> int.to_string
+    OutOfBaseRange(index, character, value, base) ->
       "digit character \""
       <> character
       <> "\" ("
@@ -90,12 +104,12 @@ pub fn to_string(error: ParseError) -> String {
       <> index |> int.to_string
       <> " is out of range for base: "
       <> base |> int.to_string
-    InvalidExponentSymbolPosition(exponent_symbol, index) ->
+    InvalidExponentSymbolPosition(index, exponent_symbol) ->
       "exponent symbol \""
       <> exponent_symbol
       <> "\" at invalid position: "
       <> index |> int.to_string
-    UnknownCharacter(character, index) ->
+    UnknownCharacter(index, character) ->
       "unknown character \""
       <> character
       <> "\" at index: "

--- a/test/data/float/invalid_float_data.gleam
+++ b/test/data/float/invalid_float_data.gleam
@@ -5,7 +5,8 @@ import parse_error.{
 }
 import test_data.{type FloatTestData, FloatTestData}
 
-const invalid_empty_or_whitespace: List(FloatTestData) = [
+// TODO: Rename all lists to make more sense
+const empty_or_whitespace: List(FloatTestData) = [
   FloatTestData(
     input: "",
     expected_program_output: Error(EmptyString),
@@ -53,7 +54,7 @@ const invalid_empty_or_whitespace: List(FloatTestData) = [
   ),
 ]
 
-const invalid_decimal_positions: List(FloatTestData) = [
+const decimal_position: List(FloatTestData) = [
   FloatTestData(
     input: "..1",
     expected_program_output: Error(InvalidDecimalPosition(0)),
@@ -96,7 +97,7 @@ const invalid_decimal_positions: List(FloatTestData) = [
   ),
 ]
 
-const invalid_underscore_positions: List(FloatTestData) = [
+const underscore_position: List(FloatTestData) = [
   FloatTestData(
     input: "_.",
     expected_program_output: Error(InvalidUnderscorePosition(0)),
@@ -159,113 +160,113 @@ const invalid_underscore_positions: List(FloatTestData) = [
   ),
 ]
 
-const invalid_characters: List(FloatTestData) = [
+const character: List(FloatTestData) = [
   FloatTestData(
     input: ". ",
-    expected_program_output: Error(UnknownCharacter(" ", 1)),
+    expected_program_output: Error(UnknownCharacter(1, " ")),
     expected_python_output: Error(Nil),
   ),
   FloatTestData(
     input: "abc",
-    expected_program_output: Error(UnknownCharacter("a", 0)),
+    expected_program_output: Error(UnknownCharacter(0, "a")),
     expected_python_output: Error(Nil),
   ),
   FloatTestData(
     input: "100.00c01",
-    expected_program_output: Error(UnknownCharacter("c", 6)),
+    expected_program_output: Error(UnknownCharacter(6, "c")),
     expected_python_output: Error(Nil),
   ),
   FloatTestData(
     input: "3.14f",
-    expected_program_output: Error(UnknownCharacter("f", 4)),
+    expected_program_output: Error(UnknownCharacter(4, "f")),
     expected_python_output: Error(Nil),
   ),
   FloatTestData(
     input: "$100.00",
-    expected_program_output: Error(UnknownCharacter("$", 0)),
+    expected_program_output: Error(UnknownCharacter(0, "$")),
     expected_python_output: Error(Nil),
   ),
 ]
 
-const invalid_exponent_positions: List(FloatTestData) = [
+const exponent_position: List(FloatTestData) = [
   FloatTestData(
     input: "e",
-    expected_program_output: Error(InvalidExponentSymbolPosition("e", 0)),
+    expected_program_output: Error(InvalidExponentSymbolPosition(0, "e")),
     expected_python_output: Error(Nil),
   ),
   FloatTestData(
     input: "E",
-    expected_program_output: Error(InvalidExponentSymbolPosition("E", 0)),
+    expected_program_output: Error(InvalidExponentSymbolPosition(0, "E")),
     expected_python_output: Error(Nil),
   ),
   FloatTestData(
     input: "e4",
-    expected_program_output: Error(InvalidExponentSymbolPosition("e", 0)),
+    expected_program_output: Error(InvalidExponentSymbolPosition(0, "e")),
     expected_python_output: Error(Nil),
   ),
   FloatTestData(
     input: "E4",
-    expected_program_output: Error(InvalidExponentSymbolPosition("E", 0)),
+    expected_program_output: Error(InvalidExponentSymbolPosition(0, "E")),
     expected_python_output: Error(Nil),
   ),
   FloatTestData(
     input: "4e",
-    expected_program_output: Error(InvalidExponentSymbolPosition("e", 1)),
+    expected_program_output: Error(InvalidExponentSymbolPosition(1, "e")),
     expected_python_output: Error(Nil),
   ),
   FloatTestData(
     input: "4E",
-    expected_program_output: Error(InvalidExponentSymbolPosition("E", 1)),
+    expected_program_output: Error(InvalidExponentSymbolPosition(1, "E")),
     expected_python_output: Error(Nil),
   ),
   FloatTestData(
     input: "4.e",
-    expected_program_output: Error(InvalidExponentSymbolPosition("e", 2)),
+    expected_program_output: Error(InvalidExponentSymbolPosition(2, "e")),
     expected_python_output: Error(Nil),
   ),
   FloatTestData(
     input: "4.E",
-    expected_program_output: Error(InvalidExponentSymbolPosition("E", 2)),
+    expected_program_output: Error(InvalidExponentSymbolPosition(2, "E")),
     expected_python_output: Error(Nil),
   ),
   FloatTestData(
     input: "4e.",
-    expected_program_output: Error(InvalidExponentSymbolPosition("e", 1)),
+    expected_program_output: Error(InvalidExponentSymbolPosition(1, "e")),
     expected_python_output: Error(Nil),
   ),
   FloatTestData(
     input: "4E.",
-    expected_program_output: Error(InvalidExponentSymbolPosition("E", 1)),
+    expected_program_output: Error(InvalidExponentSymbolPosition(1, "E")),
     expected_python_output: Error(Nil),
   ),
   FloatTestData(
     input: "E4.0",
-    expected_program_output: Error(InvalidExponentSymbolPosition("E", 0)),
+    expected_program_output: Error(InvalidExponentSymbolPosition(0, "E")),
     expected_python_output: Error(Nil),
   ),
   FloatTestData(
     input: "4.0E",
-    expected_program_output: Error(InvalidExponentSymbolPosition("E", 3)),
+    expected_program_output: Error(InvalidExponentSymbolPosition(3, "E")),
     expected_python_output: Error(Nil),
   ),
   FloatTestData(
     input: "1_234.e-4e",
-    expected_program_output: Error(InvalidExponentSymbolPosition("e", 9)),
+    expected_program_output: Error(InvalidExponentSymbolPosition(9, "e")),
     expected_python_output: Error(Nil),
   ),
   FloatTestData(
     input: "1e2e3",
-    expected_program_output: Error(InvalidExponentSymbolPosition("e", 3)),
+    expected_program_output: Error(InvalidExponentSymbolPosition(3, "e")),
     expected_python_output: Error(Nil),
   ),
   FloatTestData(
     input: "1E2E3",
-    expected_program_output: Error(InvalidExponentSymbolPosition("E", 3)),
+    expected_program_output: Error(InvalidExponentSymbolPosition(3, "E")),
     expected_python_output: Error(Nil),
   ),
 ]
 
-const invalid_mixed: List(FloatTestData) = [
+const mixed: List(FloatTestData) = [
   FloatTestData(
     input: "4.0E_2",
     expected_program_output: Error(InvalidUnderscorePosition(4)),
@@ -318,29 +319,29 @@ const invalid_mixed: List(FloatTestData) = [
   ),
   FloatTestData(
     input: " 4.0E",
-    expected_program_output: Error(InvalidExponentSymbolPosition("E", 4)),
+    expected_program_output: Error(InvalidExponentSymbolPosition(4, "E")),
     expected_python_output: Error(Nil),
   ),
   FloatTestData(
     input: "4.0E ",
-    expected_program_output: Error(UnknownCharacter(" ", 4)),
+    expected_program_output: Error(UnknownCharacter(4, " ")),
     expected_python_output: Error(Nil),
   ),
   FloatTestData(
     input: " 4.0E ",
-    expected_program_output: Error(UnknownCharacter(" ", 5)),
+    expected_program_output: Error(UnknownCharacter(5, " ")),
     expected_python_output: Error(Nil),
   ),
 ]
 
 pub fn data() -> List(FloatTestData) {
   [
-    invalid_empty_or_whitespace,
-    invalid_decimal_positions,
-    invalid_underscore_positions,
-    invalid_characters,
-    invalid_exponent_positions,
-    invalid_mixed,
+    empty_or_whitespace,
+    decimal_position,
+    underscore_position,
+    character,
+    exponent_position,
+    mixed,
   ]
   |> list.flatten
 }

--- a/test/data/float/invalid_float_data.gleam
+++ b/test/data/float/invalid_float_data.gleam
@@ -5,8 +5,7 @@ import parse_error.{
 }
 import test_data.{type FloatTestData, FloatTestData}
 
-// TODO: Rename all lists to make more sense
-const empty_or_whitespace: List(FloatTestData) = [
+const invalid_empty_or_whitespace: List(FloatTestData) = [
   FloatTestData(
     input: "",
     expected_program_output: Error(EmptyString),
@@ -54,7 +53,7 @@ const empty_or_whitespace: List(FloatTestData) = [
   ),
 ]
 
-const decimal_position: List(FloatTestData) = [
+const invalid_decimal_position: List(FloatTestData) = [
   FloatTestData(
     input: "..1",
     expected_program_output: Error(InvalidDecimalPosition(0)),
@@ -97,7 +96,7 @@ const decimal_position: List(FloatTestData) = [
   ),
 ]
 
-const underscore_position: List(FloatTestData) = [
+const invalid_underscore_position: List(FloatTestData) = [
   FloatTestData(
     input: "_.",
     expected_program_output: Error(InvalidUnderscorePosition(0)),
@@ -160,7 +159,7 @@ const underscore_position: List(FloatTestData) = [
   ),
 ]
 
-const character: List(FloatTestData) = [
+const unknown_character: List(FloatTestData) = [
   FloatTestData(
     input: ". ",
     expected_program_output: Error(UnknownCharacter(1, " ")),
@@ -188,7 +187,7 @@ const character: List(FloatTestData) = [
   ),
 ]
 
-const exponent_position: List(FloatTestData) = [
+const invalid_exponent_symbol_position: List(FloatTestData) = [
   FloatTestData(
     input: "e",
     expected_program_output: Error(InvalidExponentSymbolPosition(0, "e")),
@@ -266,7 +265,7 @@ const exponent_position: List(FloatTestData) = [
   ),
 ]
 
-const mixed: List(FloatTestData) = [
+const invalid_mixed: List(FloatTestData) = [
   FloatTestData(
     input: "4.0E_2",
     expected_program_output: Error(InvalidUnderscorePosition(4)),
@@ -336,12 +335,12 @@ const mixed: List(FloatTestData) = [
 
 pub fn data() -> List(FloatTestData) {
   [
-    empty_or_whitespace,
-    decimal_position,
-    underscore_position,
-    character,
-    exponent_position,
-    mixed,
+    invalid_empty_or_whitespace,
+    invalid_decimal_position,
+    invalid_underscore_position,
+    unknown_character,
+    invalid_exponent_symbol_position,
+    invalid_mixed,
   ]
   |> list.flatten
 }

--- a/test/data/float/valid_float_data.gleam
+++ b/test/data/float/valid_float_data.gleam
@@ -1,8 +1,7 @@
 import gleam/list
 import test_data.{type FloatTestData, FloatTestData}
 
-// TODO: Rename all lists to make more sense
-const simple_float: List(FloatTestData) = [
+const valid_simple: List(FloatTestData) = [
   FloatTestData(
     input: "1.001",
     expected_program_output: Ok(1.001),
@@ -80,7 +79,7 @@ const simple_float: List(FloatTestData) = [
   ),
 ]
 
-const float_with_underscore: List(FloatTestData) = [
+const valid_underscore: List(FloatTestData) = [
   FloatTestData(
     input: "1_000_000.0",
     expected_program_output: Ok(1_000_000.0),
@@ -108,7 +107,7 @@ const float_with_underscore: List(FloatTestData) = [
   ),
 ]
 
-const float_with_whitespace: List(FloatTestData) = [
+const valid_whitespace: List(FloatTestData) = [
   FloatTestData(
     input: " 1 ",
     expected_program_output: Ok(1.0),
@@ -136,7 +135,7 @@ const float_with_whitespace: List(FloatTestData) = [
   ),
 ]
 
-const float_with_exponent: List(FloatTestData) = [
+const valid_exponent_symbol_position: List(FloatTestData) = [
   FloatTestData(
     input: "4e3",
     expected_program_output: Ok(4000.0),
@@ -214,7 +213,7 @@ const float_with_exponent: List(FloatTestData) = [
   ),
 ]
 
-const mixed: List(FloatTestData) = [
+const valid_mixed: List(FloatTestData) = [
   FloatTestData(
     input: "   -30.01e-2   ",
     expected_program_output: Ok(-0.3001),
@@ -239,11 +238,11 @@ const mixed: List(FloatTestData) = [
 
 pub fn data() -> List(FloatTestData) {
   [
-    simple_float,
-    float_with_underscore,
-    float_with_whitespace,
-    float_with_exponent,
-    mixed,
+    valid_simple,
+    valid_underscore,
+    valid_whitespace,
+    valid_exponent_symbol_position,
+    valid_mixed,
   ]
   |> list.flatten
 }

--- a/test/data/float/valid_float_data.gleam
+++ b/test/data/float/valid_float_data.gleam
@@ -1,7 +1,8 @@
 import gleam/list
 import test_data.{type FloatTestData, FloatTestData}
 
-const valid_simple_floats: List(FloatTestData) = [
+// TODO: Rename all lists to make more sense
+const simple_float: List(FloatTestData) = [
   FloatTestData(
     input: "1.001",
     expected_program_output: Ok(1.001),
@@ -79,7 +80,7 @@ const valid_simple_floats: List(FloatTestData) = [
   ),
 ]
 
-const valid_floats_with_underscores: List(FloatTestData) = [
+const float_with_underscore: List(FloatTestData) = [
   FloatTestData(
     input: "1_000_000.0",
     expected_program_output: Ok(1_000_000.0),
@@ -107,7 +108,7 @@ const valid_floats_with_underscores: List(FloatTestData) = [
   ),
 ]
 
-const valid_floats_with_whitespace: List(FloatTestData) = [
+const float_with_whitespace: List(FloatTestData) = [
   FloatTestData(
     input: " 1 ",
     expected_program_output: Ok(1.0),
@@ -135,7 +136,7 @@ const valid_floats_with_whitespace: List(FloatTestData) = [
   ),
 ]
 
-const valid_floats_with_exponents: List(FloatTestData) = [
+const float_with_exponent: List(FloatTestData) = [
   FloatTestData(
     input: "4e3",
     expected_program_output: Ok(4000.0),
@@ -213,7 +214,7 @@ const valid_floats_with_exponents: List(FloatTestData) = [
   ),
 ]
 
-const valid_mixed: List(FloatTestData) = [
+const mixed: List(FloatTestData) = [
   FloatTestData(
     input: "   -30.01e-2   ",
     expected_program_output: Ok(-0.3001),
@@ -238,11 +239,11 @@ const valid_mixed: List(FloatTestData) = [
 
 pub fn data() -> List(FloatTestData) {
   [
-    valid_simple_floats,
-    valid_floats_with_underscores,
-    valid_floats_with_whitespace,
-    valid_floats_with_exponents,
-    valid_mixed,
+    simple_float,
+    float_with_underscore,
+    float_with_whitespace,
+    float_with_exponent,
+    mixed,
   ]
   |> list.flatten
 }

--- a/test/data/integer/invalid_integer_data.gleam
+++ b/test/data/integer/invalid_integer_data.gleam
@@ -1,12 +1,13 @@
 import gleam/list
 import parse_error.{
-  EmptyString, InvalidBaseValue, InvalidDigitPosition, InvalidSignPosition,
-  InvalidUnderscorePosition, OutOfBaseRange, UnknownCharacter,
-  WhitespaceOnlyString,
+  BasePrefixOnly, EmptyString, InvalidBaseValue, InvalidDigitPosition,
+  InvalidSignPosition, InvalidUnderscorePosition, OutOfBaseRange,
+  UnknownCharacter, WhitespaceOnlyString,
 }
 import test_data.{type IntegerTestData, IntegerTestData}
 
-const invalid_empty_or_whitespace: List(IntegerTestData) = [
+// TODO: Rename all lists to make more sense
+const empty_or_whitespace: List(IntegerTestData) = [
   IntegerTestData(
     input: "",
     base: 10,
@@ -63,7 +64,7 @@ const invalid_empty_or_whitespace: List(IntegerTestData) = [
   ),
 ]
 
-const invalid_underscore_positions: List(IntegerTestData) = [
+const underscore_position: List(IntegerTestData) = [
   IntegerTestData(
     input: "_",
     base: 10,
@@ -132,214 +133,214 @@ const invalid_underscore_positions: List(IntegerTestData) = [
   ),
 ]
 
-const invalid_characters: List(IntegerTestData) = [
+const characters: List(IntegerTestData) = [
   IntegerTestData(
     input: "+ 1",
     base: 10,
-    expected_program_output: Error(UnknownCharacter(" ", 1)),
+    expected_program_output: Error(UnknownCharacter(1, " ")),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: ".",
     base: 10,
-    expected_program_output: Error(UnknownCharacter(".", 0)),
+    expected_program_output: Error(UnknownCharacter(0, ".")),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "..",
     base: 10,
-    expected_program_output: Error(UnknownCharacter(".", 0)),
+    expected_program_output: Error(UnknownCharacter(0, ".")),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "0.0.",
     base: 10,
-    expected_program_output: Error(UnknownCharacter(".", 1)),
+    expected_program_output: Error(UnknownCharacter(1, ".")),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: ".0.0",
     base: 10,
-    expected_program_output: Error(UnknownCharacter(".", 0)),
+    expected_program_output: Error(UnknownCharacter(0, ".")),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "1.",
     base: 10,
-    expected_program_output: Error(UnknownCharacter(".", 1)),
+    expected_program_output: Error(UnknownCharacter(1, ".")),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "1.0",
     base: 10,
-    expected_program_output: Error(UnknownCharacter(".", 1)),
+    expected_program_output: Error(UnknownCharacter(1, ".")),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "1$",
     base: 10,
-    expected_program_output: Error(UnknownCharacter("$", 1)),
+    expected_program_output: Error(UnknownCharacter(1, "$")),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "#123",
     base: 10,
-    expected_program_output: Error(UnknownCharacter("#", 0)),
+    expected_program_output: Error(UnknownCharacter(0, "#")),
     expected_python_output: Error(Nil),
   ),
 ]
 
-const invalid_base_range: List(IntegerTestData) = [
+const base_range: List(IntegerTestData) = [
   IntegerTestData(
     input: "a",
     base: 10,
-    expected_program_output: Error(OutOfBaseRange("a", 10, 10, 0)),
+    expected_program_output: Error(OutOfBaseRange(0, "a", 10, 10)),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "1b1",
     base: 10,
-    expected_program_output: Error(OutOfBaseRange("b", 11, 10, 1)),
+    expected_program_output: Error(OutOfBaseRange(1, "b", 11, 10)),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "abc",
     base: 10,
-    expected_program_output: Error(OutOfBaseRange("a", 10, 10, 0)),
+    expected_program_output: Error(OutOfBaseRange(0, "a", 10, 10)),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "e",
     base: 10,
-    expected_program_output: Error(OutOfBaseRange("e", 14, 10, 0)),
+    expected_program_output: Error(OutOfBaseRange(0, "e", 14, 10)),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "E",
     base: 10,
-    expected_program_output: Error(OutOfBaseRange("E", 14, 10, 0)),
+    expected_program_output: Error(OutOfBaseRange(0, "E", 14, 10)),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "e13",
     base: 10,
-    expected_program_output: Error(OutOfBaseRange("e", 14, 10, 0)),
+    expected_program_output: Error(OutOfBaseRange(0, "e", 14, 10)),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "1e3",
     base: 10,
-    expected_program_output: Error(OutOfBaseRange("e", 14, 10, 1)),
+    expected_program_output: Error(OutOfBaseRange(1, "e", 14, 10)),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "13e",
     base: 10,
-    expected_program_output: Error(OutOfBaseRange("e", 14, 10, 2)),
+    expected_program_output: Error(OutOfBaseRange(2, "e", 14, 10)),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "E13",
     base: 10,
-    expected_program_output: Error(OutOfBaseRange("E", 14, 10, 0)),
+    expected_program_output: Error(OutOfBaseRange(0, "E", 14, 10)),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "1E3",
     base: 10,
-    expected_program_output: Error(OutOfBaseRange("E", 14, 10, 1)),
+    expected_program_output: Error(OutOfBaseRange(1, "E", 14, 10)),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "13E",
     base: 10,
-    expected_program_output: Error(OutOfBaseRange("E", 14, 10, 2)),
+    expected_program_output: Error(OutOfBaseRange(2, "E", 14, 10)),
     expected_python_output: Error(Nil),
   ),
 ]
 
-const invalid_digit_positions: List(IntegerTestData) = [
+const digit_position: List(IntegerTestData) = [
   IntegerTestData(
     input: "1 1",
     base: 10,
-    expected_program_output: Error(InvalidDigitPosition("1", 2)),
+    expected_program_output: Error(InvalidDigitPosition(2, "1")),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: " 12 34 ",
     base: 10,
-    expected_program_output: Error(InvalidDigitPosition("3", 4)),
+    expected_program_output: Error(InvalidDigitPosition(4, "3")),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "1 2 3",
     base: 10,
-    expected_program_output: Error(InvalidDigitPosition("2", 2)),
+    expected_program_output: Error(InvalidDigitPosition(2, "2")),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "123 456",
     base: 10,
-    expected_program_output: Error(InvalidDigitPosition("4", 4)),
+    expected_program_output: Error(InvalidDigitPosition(4, "4")),
     expected_python_output: Error(Nil),
   ),
 ]
 
-const invalid_sign_positions: List(IntegerTestData) = [
+const sign_position: List(IntegerTestData) = [
   IntegerTestData(
     input: "1+",
     base: 10,
-    expected_program_output: Error(InvalidSignPosition("+", 1)),
+    expected_program_output: Error(InvalidSignPosition(1, "+")),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "1-",
     base: 10,
-    expected_program_output: Error(InvalidSignPosition("-", 1)),
+    expected_program_output: Error(InvalidSignPosition(1, "-")),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "1+1",
     base: 10,
-    expected_program_output: Error(InvalidSignPosition("+", 1)),
+    expected_program_output: Error(InvalidSignPosition(1, "+")),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "1-1",
     base: 10,
-    expected_program_output: Error(InvalidSignPosition("-", 1)),
+    expected_program_output: Error(InvalidSignPosition(1, "-")),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "++1",
     base: 10,
-    expected_program_output: Error(InvalidSignPosition("+", 1)),
+    expected_program_output: Error(InvalidSignPosition(1, "+")),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "--1",
     base: 10,
-    expected_program_output: Error(InvalidSignPosition("-", 1)),
+    expected_program_output: Error(InvalidSignPosition(1, "-")),
     expected_python_output: Error(Nil),
   ),
 ]
 
-const invalid_base_configurations: List(IntegerTestData) = [
+const base_configuration: List(IntegerTestData) = [
   IntegerTestData(
     input: "151",
     base: 2,
-    expected_program_output: Error(OutOfBaseRange("5", 5, 2, 1)),
+    expected_program_output: Error(OutOfBaseRange(1, "5", 5, 2)),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "DEAD_BEEF",
     base: 10,
-    expected_program_output: Error(OutOfBaseRange("D", 13, 10, 0)),
+    expected_program_output: Error(OutOfBaseRange(0, "D", 13, 10)),
     expected_python_output: Error(Nil),
   ),
 ]
 
-const invalid_base_value: List(IntegerTestData) = [
+const base_value: List(IntegerTestData) = [
   IntegerTestData(
     input: "151",
     base: 1,
@@ -354,59 +355,59 @@ const invalid_base_value: List(IntegerTestData) = [
   ),
 ]
 
-const invalid_mixed: List(IntegerTestData) = [
+const mixed: List(IntegerTestData) = [
   IntegerTestData(
     input: "e_1_3",
     base: 10,
-    expected_program_output: Error(OutOfBaseRange("e", 14, 10, 0)),
+    expected_program_output: Error(OutOfBaseRange(0, "e", 14, 10)),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "1_3_e",
     base: 10,
-    expected_program_output: Error(OutOfBaseRange("e", 14, 10, 4)),
+    expected_program_output: Error(OutOfBaseRange(4, "e", 14, 10)),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "1._3_e",
     base: 10,
-    expected_program_output: Error(UnknownCharacter(".", 1)),
+    expected_program_output: Error(UnknownCharacter(1, ".")),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "1+._3_e",
     base: 10,
-    expected_program_output: Error(InvalidSignPosition("+", 1)),
+    expected_program_output: Error(InvalidSignPosition(1, "+")),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "1 1+._3_e",
     base: 10,
-    expected_program_output: Error(InvalidDigitPosition("1", 2)),
+    expected_program_output: Error(InvalidDigitPosition(2, "1")),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "1_a_2",
     base: 10,
-    expected_program_output: Error(OutOfBaseRange("a", 10, 10, 2)),
+    expected_program_output: Error(OutOfBaseRange(2, "a", 10, 10)),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "+1.2_3",
     base: 10,
-    expected_program_output: Error(UnknownCharacter(".", 2)),
+    expected_program_output: Error(UnknownCharacter(2, ".")),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "  1_f_1  ",
     base: 2,
-    expected_program_output: Error(OutOfBaseRange("f", 15, 2, 4)),
+    expected_program_output: Error(OutOfBaseRange(4, "f", 15, 2)),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
     input: "  1._5_1  ",
     base: 2,
-    expected_program_output: Error(UnknownCharacter(".", 3)),
+    expected_program_output: Error(UnknownCharacter(3, ".")),
     expected_python_output: Error(Nil),
   ),
   IntegerTestData(
@@ -415,19 +416,84 @@ const invalid_mixed: List(IntegerTestData) = [
     expected_program_output: Error(InvalidUnderscorePosition(6)),
     expected_python_output: Error(Nil),
   ),
+  // Base 0, has no prefix, default to decimal, but error because of UnknownCharacter
+  IntegerTestData(
+    input: " \n6_666.",
+    base: 0,
+    expected_program_output: Error(UnknownCharacter(7, ".")),
+    expected_python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: " \n0x ABC.",
+    base: 0,
+    expected_program_output: Error(UnknownCharacter(4, " ")),
+    expected_python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: " \n0xA BC.",
+    base: 0,
+    expected_program_output: Error(InvalidDigitPosition(6, "B")),
+    expected_python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: " \n0b101 1",
+    base: 0,
+    expected_program_output: Error(InvalidDigitPosition(8, "1")),
+    expected_python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "0xDEAD_BEEF_",
+    base: 0,
+    expected_program_output: Error(InvalidUnderscorePosition(11)),
+    expected_python_output: Error(Nil),
+  ),
+]
+
+const base_prefix_configuration: List(IntegerTestData) = [
+  IntegerTestData(
+    input: "  0b",
+    base: 0,
+    expected_program_output: Error(BasePrefixOnly(#(2, 4), "0b")),
+    expected_python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "  0b  ",
+    base: 0,
+    expected_program_output: Error(UnknownCharacter(4, " ")),
+    expected_python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "0b100b",
+    base: 0,
+    expected_program_output: Error(OutOfBaseRange(5, "b", 11, 2)),
+    expected_python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "0b1001",
+    base: 8,
+    expected_program_output: Error(OutOfBaseRange(1, "b", 11, 8)),
+    expected_python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "0XABCD",
+    base: 2,
+    expected_program_output: Error(OutOfBaseRange(1, "X", 33, 2)),
+    expected_python_output: Error(Nil),
+  ),
 ]
 
 pub fn data() -> List(IntegerTestData) {
   [
-    invalid_empty_or_whitespace,
-    invalid_underscore_positions,
-    invalid_characters,
-    invalid_base_range,
-    invalid_digit_positions,
-    invalid_sign_positions,
-    invalid_base_configurations,
-    invalid_base_value,
-    invalid_mixed,
+    empty_or_whitespace,
+    underscore_position,
+    characters,
+    base_range,
+    digit_position,
+    sign_position,
+    base_configuration,
+    base_value,
+    base_prefix_configuration,
+    mixed,
   ]
   |> list.flatten
 }

--- a/test/data/integer/invalid_integer_data.gleam
+++ b/test/data/integer/invalid_integer_data.gleam
@@ -6,8 +6,7 @@ import parse_error.{
 }
 import test_data.{type IntegerTestData, IntegerTestData}
 
-// TODO: Rename all lists to make more sense
-const empty_or_whitespace: List(IntegerTestData) = [
+const invalid_empty_or_whitespace: List(IntegerTestData) = [
   IntegerTestData(
     input: "",
     base: 10,
@@ -64,7 +63,7 @@ const empty_or_whitespace: List(IntegerTestData) = [
   ),
 ]
 
-const underscore_position: List(IntegerTestData) = [
+const invalid_underscore_position: List(IntegerTestData) = [
   IntegerTestData(
     input: "_",
     base: 10,
@@ -133,7 +132,7 @@ const underscore_position: List(IntegerTestData) = [
   ),
 ]
 
-const characters: List(IntegerTestData) = [
+const unknown_character: List(IntegerTestData) = [
   IntegerTestData(
     input: "+ 1",
     base: 10,
@@ -190,7 +189,7 @@ const characters: List(IntegerTestData) = [
   ),
 ]
 
-const base_range: List(IntegerTestData) = [
+const out_of_base_range: List(IntegerTestData) = [
   IntegerTestData(
     input: "a",
     base: 10,
@@ -257,9 +256,21 @@ const base_range: List(IntegerTestData) = [
     expected_program_output: Error(OutOfBaseRange(2, "E", 14, 10)),
     expected_python_output: Error(Nil),
   ),
+  IntegerTestData(
+    input: "151",
+    base: 2,
+    expected_program_output: Error(OutOfBaseRange(1, "5", 5, 2)),
+    expected_python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "DEAD_BEEF",
+    base: 10,
+    expected_program_output: Error(OutOfBaseRange(0, "D", 13, 10)),
+    expected_python_output: Error(Nil),
+  ),
 ]
 
-const digit_position: List(IntegerTestData) = [
+const invalid_digit_position: List(IntegerTestData) = [
   IntegerTestData(
     input: "1 1",
     base: 10,
@@ -286,7 +297,7 @@ const digit_position: List(IntegerTestData) = [
   ),
 ]
 
-const sign_position: List(IntegerTestData) = [
+const invalid_sign_position: List(IntegerTestData) = [
   IntegerTestData(
     input: "1+",
     base: 10,
@@ -325,22 +336,7 @@ const sign_position: List(IntegerTestData) = [
   ),
 ]
 
-const base_configuration: List(IntegerTestData) = [
-  IntegerTestData(
-    input: "151",
-    base: 2,
-    expected_program_output: Error(OutOfBaseRange(1, "5", 5, 2)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "DEAD_BEEF",
-    base: 10,
-    expected_program_output: Error(OutOfBaseRange(0, "D", 13, 10)),
-    expected_python_output: Error(Nil),
-  ),
-]
-
-const base_value: List(IntegerTestData) = [
+const invalid_base_value: List(IntegerTestData) = [
   IntegerTestData(
     input: "151",
     base: 1,
@@ -355,7 +351,40 @@ const base_value: List(IntegerTestData) = [
   ),
 ]
 
-const mixed: List(IntegerTestData) = [
+const base_prefix_only: List(IntegerTestData) = [
+  IntegerTestData(
+    input: "  0b",
+    base: 0,
+    expected_program_output: Error(BasePrefixOnly(#(2, 4), "0b")),
+    expected_python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "  0b  ",
+    base: 0,
+    expected_program_output: Error(UnknownCharacter(4, " ")),
+    expected_python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "0b100b",
+    base: 0,
+    expected_program_output: Error(OutOfBaseRange(5, "b", 11, 2)),
+    expected_python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "0b1001",
+    base: 8,
+    expected_program_output: Error(OutOfBaseRange(1, "b", 11, 8)),
+    expected_python_output: Error(Nil),
+  ),
+  IntegerTestData(
+    input: "0XABCD",
+    base: 2,
+    expected_program_output: Error(OutOfBaseRange(1, "X", 33, 2)),
+    expected_python_output: Error(Nil),
+  ),
+]
+
+const invalid_mixed: List(IntegerTestData) = [
   IntegerTestData(
     input: "e_1_3",
     base: 10,
@@ -449,51 +478,17 @@ const mixed: List(IntegerTestData) = [
   ),
 ]
 
-const base_prefix_configuration: List(IntegerTestData) = [
-  IntegerTestData(
-    input: "  0b",
-    base: 0,
-    expected_program_output: Error(BasePrefixOnly(#(2, 4), "0b")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "  0b  ",
-    base: 0,
-    expected_program_output: Error(UnknownCharacter(4, " ")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "0b100b",
-    base: 0,
-    expected_program_output: Error(OutOfBaseRange(5, "b", 11, 2)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "0b1001",
-    base: 8,
-    expected_program_output: Error(OutOfBaseRange(1, "b", 11, 8)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "0XABCD",
-    base: 2,
-    expected_program_output: Error(OutOfBaseRange(1, "X", 33, 2)),
-    expected_python_output: Error(Nil),
-  ),
-]
-
 pub fn data() -> List(IntegerTestData) {
   [
-    empty_or_whitespace,
-    underscore_position,
-    characters,
-    base_range,
-    digit_position,
-    sign_position,
-    base_configuration,
-    base_value,
-    base_prefix_configuration,
-    mixed,
+    invalid_empty_or_whitespace,
+    invalid_underscore_position,
+    unknown_character,
+    out_of_base_range,
+    invalid_digit_position,
+    invalid_sign_position,
+    invalid_base_value,
+    base_prefix_only,
+    invalid_mixed,
   ]
   |> list.flatten
 }

--- a/test/data/integer/valid_integer_data.gleam
+++ b/test/data/integer/valid_integer_data.gleam
@@ -1,9 +1,7 @@
 import gleam/list
 import test_data.{type IntegerTestData, IntegerTestData}
 
-// TODO: Comment all test data, put into one list?
-// TODO: Rename all lists to make more sense
-const simple_integer: List(IntegerTestData) = [
+const valid_simple: List(IntegerTestData) = [
   IntegerTestData(
     input: "1",
     base: 10,
@@ -60,103 +58,7 @@ const simple_integer: List(IntegerTestData) = [
   ),
 ]
 
-const integer_with_underscore: List(IntegerTestData) = [
-  IntegerTestData(
-    input: "1_000",
-    base: 10,
-    expected_program_output: Ok(1000),
-    expected_python_output: Ok("1000"),
-  ),
-  IntegerTestData(
-    input: "1_000_000",
-    base: 10,
-    expected_program_output: Ok(1_000_000),
-    expected_python_output: Ok("1000000"),
-  ),
-  IntegerTestData(
-    input: "1_234_567_890",
-    base: 10,
-    expected_program_output: Ok(1_234_567_890),
-    expected_python_output: Ok("1234567890"),
-  ),
-  IntegerTestData(
-    input: "-1_000_000",
-    base: 10,
-    expected_program_output: Ok(-1_000_000),
-    expected_python_output: Ok("-1000000"),
-  ),
-  IntegerTestData(
-    input: "+1_234_567",
-    base: 10,
-    expected_program_output: Ok(1_234_567),
-    expected_python_output: Ok("1234567"),
-  ),
-  IntegerTestData(
-    input: "9_876_543_210",
-    base: 10,
-    expected_program_output: Ok(9_876_543_210),
-    expected_python_output: Ok("9876543210"),
-  ),
-]
-
-const integer_with_whitespace: List(IntegerTestData) = [
-  IntegerTestData(
-    input: " +123 ",
-    base: 10,
-    expected_program_output: Ok(123),
-    expected_python_output: Ok("123"),
-  ),
-  IntegerTestData(
-    input: " -123 ",
-    base: 10,
-    expected_program_output: Ok(-123),
-    expected_python_output: Ok("-123"),
-  ),
-  IntegerTestData(
-    input: " 0123",
-    base: 10,
-    expected_program_output: Ok(123),
-    expected_python_output: Ok("123"),
-  ),
-  IntegerTestData(
-    input: " 1 ",
-    base: 10,
-    expected_program_output: Ok(1),
-    expected_python_output: Ok("1"),
-  ),
-  IntegerTestData(
-    input: "42 ",
-    base: 10,
-    expected_program_output: Ok(42),
-    expected_python_output: Ok("42"),
-  ),
-  IntegerTestData(
-    input: " +0 ",
-    base: 10,
-    expected_program_output: Ok(0),
-    expected_python_output: Ok("0"),
-  ),
-  IntegerTestData(
-    input: "  -987  ",
-    base: 10,
-    expected_program_output: Ok(-987),
-    expected_python_output: Ok("-987"),
-  ),
-  IntegerTestData(
-    input: "\t123\t",
-    base: 10,
-    expected_program_output: Ok(123),
-    expected_python_output: Ok("123"),
-  ),
-  IntegerTestData(
-    input: "\n456\n",
-    base: 10,
-    expected_program_output: Ok(456),
-    expected_python_output: Ok("456"),
-  ),
-]
-
-const simple_integer_base_2: List(IntegerTestData) = [
+const valid_simple_base_2: List(IntegerTestData) = [
   IntegerTestData(
     input: "0",
     base: 2,
@@ -189,7 +91,7 @@ const simple_integer_base_2: List(IntegerTestData) = [
   ),
 ]
 
-const simple_integer_base_8: List(IntegerTestData) = [
+const valid_simple_base_8: List(IntegerTestData) = [
   IntegerTestData(
     input: "0",
     base: 8,
@@ -204,7 +106,7 @@ const simple_integer_base_8: List(IntegerTestData) = [
   ),
 ]
 
-const simple_integer_base_16: List(IntegerTestData) = [
+const valid_simple_base_16: List(IntegerTestData) = [
   IntegerTestData(
     input: "DEAD_BEEF",
     base: 16,
@@ -219,7 +121,7 @@ const simple_integer_base_16: List(IntegerTestData) = [
   ),
 ]
 
-const simple_base_prefix: List(IntegerTestData) = [
+const valid_simple_base_prefix: List(IntegerTestData) = [
   // Base 0, has binary prefix
   IntegerTestData(
     input: "0b10",
@@ -278,15 +180,111 @@ const simple_base_prefix: List(IntegerTestData) = [
   ),
 ]
 
+const valid_underscore: List(IntegerTestData) = [
+  IntegerTestData(
+    input: "1_000",
+    base: 10,
+    expected_program_output: Ok(1000),
+    expected_python_output: Ok("1000"),
+  ),
+  IntegerTestData(
+    input: "1_000_000",
+    base: 10,
+    expected_program_output: Ok(1_000_000),
+    expected_python_output: Ok("1000000"),
+  ),
+  IntegerTestData(
+    input: "1_234_567_890",
+    base: 10,
+    expected_program_output: Ok(1_234_567_890),
+    expected_python_output: Ok("1234567890"),
+  ),
+  IntegerTestData(
+    input: "-1_000_000",
+    base: 10,
+    expected_program_output: Ok(-1_000_000),
+    expected_python_output: Ok("-1000000"),
+  ),
+  IntegerTestData(
+    input: "+1_234_567",
+    base: 10,
+    expected_program_output: Ok(1_234_567),
+    expected_python_output: Ok("1234567"),
+  ),
+  IntegerTestData(
+    input: "9_876_543_210",
+    base: 10,
+    expected_program_output: Ok(9_876_543_210),
+    expected_python_output: Ok("9876543210"),
+  ),
+]
+
+const valid_whitespace: List(IntegerTestData) = [
+  IntegerTestData(
+    input: " +123 ",
+    base: 10,
+    expected_program_output: Ok(123),
+    expected_python_output: Ok("123"),
+  ),
+  IntegerTestData(
+    input: " -123 ",
+    base: 10,
+    expected_program_output: Ok(-123),
+    expected_python_output: Ok("-123"),
+  ),
+  IntegerTestData(
+    input: " 0123",
+    base: 10,
+    expected_program_output: Ok(123),
+    expected_python_output: Ok("123"),
+  ),
+  IntegerTestData(
+    input: " 1 ",
+    base: 10,
+    expected_program_output: Ok(1),
+    expected_python_output: Ok("1"),
+  ),
+  IntegerTestData(
+    input: "42 ",
+    base: 10,
+    expected_program_output: Ok(42),
+    expected_python_output: Ok("42"),
+  ),
+  IntegerTestData(
+    input: " +0 ",
+    base: 10,
+    expected_program_output: Ok(0),
+    expected_python_output: Ok("0"),
+  ),
+  IntegerTestData(
+    input: "  -987  ",
+    base: 10,
+    expected_program_output: Ok(-987),
+    expected_python_output: Ok("-987"),
+  ),
+  IntegerTestData(
+    input: "\t123\t",
+    base: 10,
+    expected_program_output: Ok(123),
+    expected_python_output: Ok("123"),
+  ),
+  IntegerTestData(
+    input: "\n456\n",
+    base: 10,
+    expected_program_output: Ok(456),
+    expected_python_output: Ok("456"),
+  ),
+]
+
 pub fn data() -> List(IntegerTestData) {
   [
-    simple_integer,
-    simple_integer_base_2,
-    simple_integer_base_8,
-    simple_integer_base_16,
-    integer_with_underscore,
-    integer_with_whitespace,
-    simple_base_prefix,
+    valid_simple,
+    valid_simple_base_2,
+    valid_simple_base_8,
+    valid_simple_base_16,
+    valid_underscore,
+    valid_whitespace,
+    valid_simple_base_prefix,
   ]
   |> list.flatten
 }

--- a/test/data/integer/valid_integer_data.gleam
+++ b/test/data/integer/valid_integer_data.gleam
@@ -1,7 +1,9 @@
 import gleam/list
 import test_data.{type IntegerTestData, IntegerTestData}
 
-const valid_simple_integers: List(IntegerTestData) = [
+// TODO: Comment all test data, put into one list?
+// TODO: Rename all lists to make more sense
+const simple_integer: List(IntegerTestData) = [
   IntegerTestData(
     input: "1",
     base: 10,
@@ -58,7 +60,7 @@ const valid_simple_integers: List(IntegerTestData) = [
   ),
 ]
 
-const valid_integers_with_underscores: List(IntegerTestData) = [
+const integer_with_underscore: List(IntegerTestData) = [
   IntegerTestData(
     input: "1_000",
     base: 10,
@@ -97,7 +99,7 @@ const valid_integers_with_underscores: List(IntegerTestData) = [
   ),
 ]
 
-const valid_integers_with_whitespace: List(IntegerTestData) = [
+const integer_with_whitespace: List(IntegerTestData) = [
   IntegerTestData(
     input: " +123 ",
     base: 10,
@@ -154,7 +156,7 @@ const valid_integers_with_whitespace: List(IntegerTestData) = [
   ),
 ]
 
-const valid_simple_integers_base_2: List(IntegerTestData) = [
+const simple_integer_base_2: List(IntegerTestData) = [
   IntegerTestData(
     input: "0",
     base: 2,
@@ -187,7 +189,7 @@ const valid_simple_integers_base_2: List(IntegerTestData) = [
   ),
 ]
 
-const valid_simple_integers_base_8: List(IntegerTestData) = [
+const simple_integer_base_8: List(IntegerTestData) = [
   IntegerTestData(
     input: "0",
     base: 8,
@@ -202,7 +204,7 @@ const valid_simple_integers_base_8: List(IntegerTestData) = [
   ),
 ]
 
-const valid_simple_integers_base_16: List(IntegerTestData) = [
+const simple_integer_base_16: List(IntegerTestData) = [
   IntegerTestData(
     input: "DEAD_BEEF",
     base: 16,
@@ -217,14 +219,74 @@ const valid_simple_integers_base_16: List(IntegerTestData) = [
   ),
 ]
 
+const simple_base_prefix: List(IntegerTestData) = [
+  // Base 0, has binary prefix
+  IntegerTestData(
+    input: "0b10",
+    base: 0,
+    expected_program_output: Ok(0b10),
+    expected_python_output: Ok("2"),
+  ),
+  // Base 0, has prefix, and an underscore between the prefix and the number
+  // IntegerTestData(
+  //   input: "0x_DEAD_BEEF",
+  //   base: 0,
+  //   expected_program_output: Ok(0xDEADBEEF),
+  //   expected_python_output: Ok("3735928559"),
+  // ),
+  // Base 0, has no prefix, default to decimal
+  IntegerTestData(
+    input: " \n6_666",
+    base: 0,
+    expected_program_output: Ok(6666),
+    expected_python_output: Ok("6666"),
+  ),
+  // Base 2 and also has binary prefix
+  IntegerTestData(
+    input: "0b1001",
+    base: 2,
+    expected_program_output: Ok(0b1001),
+    expected_python_output: Ok("9"),
+  ),
+  // Base 8 and also has octal prefix
+  IntegerTestData(
+    input: "0o777",
+    base: 8,
+    expected_program_output: Ok(0o777),
+    expected_python_output: Ok("511"),
+  ),
+  // Base 16 and also has hexadecimal prefix
+  IntegerTestData(
+    input: "0xDEAD_BEEF",
+    base: 16,
+    expected_program_output: Ok(0xDEAD_BEEF),
+    expected_python_output: Ok("3735928559"),
+  ),
+  // Base 0, has octal prefix
+  IntegerTestData(
+    input: "0o01234",
+    base: 0,
+    expected_program_output: Ok(0o01234),
+    expected_python_output: Ok("668"),
+  ),
+  // Base 0, has hexadecimal prefix
+  IntegerTestData(
+    input: "0xDEADBEEF",
+    base: 0,
+    expected_program_output: Ok(0xDEADBEEF),
+    expected_python_output: Ok("3735928559"),
+  ),
+]
+
 pub fn data() -> List(IntegerTestData) {
   [
-    valid_simple_integers,
-    valid_simple_integers_base_2,
-    valid_simple_integers_base_8,
-    valid_simple_integers_base_16,
-    valid_integers_with_underscores,
-    valid_integers_with_whitespace,
+    simple_integer,
+    simple_integer_base_2,
+    simple_integer_base_8,
+    simple_integer_base_16,
+    integer_with_underscore,
+    integer_with_whitespace,
+    simple_base_prefix,
   ]
   |> list.flatten
 }

--- a/test/tokenizer_test.gleam
+++ b/test/tokenizer_test.gleam
@@ -1,5 +1,6 @@
 import lenient_parse/internal/token.{
-  DecimalPoint, Digit, ExponentSymbol, Sign, Underscore, Unknown, Whitespace,
+  BasePrefix, DecimalPoint, Digit, ExponentSymbol, Sign, Underscore, Unknown,
+  Whitespace,
 }
 import lenient_parse/internal/tokenizer
 import startest/expect
@@ -18,16 +19,16 @@ pub fn tokenize_float_test() {
     Whitespace(#(5, 6), "\r\n"),
     Sign(#(6, 7), "+", True),
     Sign(#(7, 8), "-", False),
-    Digit(#(8, 9), "0", 0, 10),
-    Digit(#(9, 10), "1", 1, 10),
-    Digit(#(10, 11), "2", 2, 10),
-    Digit(#(11, 12), "3", 3, 10),
-    Digit(#(12, 13), "4", 4, 10),
-    Digit(#(13, 14), "5", 5, 10),
-    Digit(#(14, 15), "6", 6, 10),
-    Digit(#(15, 16), "7", 7, 10),
-    Digit(#(16, 17), "8", 8, 10),
-    Digit(#(17, 18), "9", 9, 10),
+    Digit(#(8, 9), "0", 0),
+    Digit(#(9, 10), "1", 1),
+    Digit(#(10, 11), "2", 2),
+    Digit(#(11, 12), "3", 3),
+    Digit(#(12, 13), "4", 4),
+    Digit(#(13, 14), "5", 5),
+    Digit(#(14, 15), "6", 6),
+    Digit(#(15, 16), "7", 7),
+    Digit(#(16, 17), "8", 8),
+    Digit(#(17, 18), "9", 9),
     ExponentSymbol(#(18, 19), "e"),
     ExponentSymbol(#(19, 20), "E"),
     DecimalPoint(#(20, 21)),
@@ -52,24 +53,24 @@ pub fn tokenize_int_base_10_test() {
     Whitespace(#(5, 6), "\r\n"),
     Sign(#(6, 7), "+", True),
     Sign(#(7, 8), "-", False),
-    Digit(#(8, 9), "0", 0, 10),
-    Digit(#(9, 10), "1", 1, 10),
-    Digit(#(10, 11), "2", 2, 10),
-    Digit(#(11, 12), "3", 3, 10),
-    Digit(#(12, 13), "4", 4, 10),
-    Digit(#(13, 14), "5", 5, 10),
-    Digit(#(14, 15), "6", 6, 10),
-    Digit(#(15, 16), "7", 7, 10),
-    Digit(#(16, 17), "8", 8, 10),
-    Digit(#(17, 18), "9", 9, 10),
-    Digit(#(18, 19), "e", 14, 10),
-    Digit(#(19, 20), "E", 14, 10),
+    Digit(#(8, 9), "0", 0),
+    Digit(#(9, 10), "1", 1),
+    Digit(#(10, 11), "2", 2),
+    Digit(#(11, 12), "3", 3),
+    Digit(#(12, 13), "4", 4),
+    Digit(#(13, 14), "5", 5),
+    Digit(#(14, 15), "6", 6),
+    Digit(#(15, 16), "7", 7),
+    Digit(#(16, 17), "8", 8),
+    Digit(#(17, 18), "9", 9),
+    Digit(#(18, 19), "e", 14),
+    Digit(#(19, 20), "E", 14),
     Unknown(#(20, 21), "."),
     Underscore(#(21, 22)),
-    Digit(#(22, 23), "a", 10, 10),
-    Digit(#(23, 24), "b", 11, 10),
-    Digit(#(24, 25), "c", 12, 10),
-    Digit(#(25, 26), "Z", 35, 10),
+    Digit(#(22, 23), "a", 10),
+    Digit(#(23, 24), "b", 11),
+    Digit(#(24, 25), "c", 12),
+    Digit(#(25, 26), "Z", 35),
   ])
 }
 
@@ -77,13 +78,13 @@ pub fn tokenize_int_base_2_test() {
   "0102101"
   |> tokenizer.tokenize_int(base: 2)
   |> expect.to_equal([
-    Digit(#(0, 1), "0", 0, 2),
-    Digit(#(1, 2), "1", 1, 2),
-    Digit(#(2, 3), "0", 0, 2),
-    Digit(#(3, 4), "2", 2, 2),
-    Digit(#(4, 5), "1", 1, 2),
-    Digit(#(5, 6), "0", 0, 2),
-    Digit(#(6, 7), "1", 1, 2),
+    Digit(#(0, 1), "0", 0),
+    Digit(#(1, 2), "1", 1),
+    Digit(#(2, 3), "0", 0),
+    Digit(#(3, 4), "2", 2),
+    Digit(#(4, 5), "1", 1),
+    Digit(#(5, 6), "0", 0),
+    Digit(#(6, 7), "1", 1),
   ])
 }
 
@@ -91,16 +92,16 @@ pub fn tokenize_int_base_16_test() {
   "dead_beefZ"
   |> tokenizer.tokenize_int(base: 16)
   |> expect.to_equal([
-    Digit(#(0, 1), "d", 0xD, 16),
-    Digit(#(1, 2), "e", 0xE, 16),
-    Digit(#(2, 3), "a", 0xA, 16),
-    Digit(#(3, 4), "d", 0xD, 16),
+    Digit(#(0, 1), "d", 0xD),
+    Digit(#(1, 2), "e", 0xE),
+    Digit(#(2, 3), "a", 0xA),
+    Digit(#(3, 4), "d", 0xD),
     Underscore(#(4, 5)),
-    Digit(#(5, 6), "b", 0xB, 16),
-    Digit(#(6, 7), "e", 0xE, 16),
-    Digit(#(7, 8), "e", 0xE, 16),
-    Digit(#(8, 9), "f", 0xF, 16),
-    Digit(#(9, 10), "Z", 35, 16),
+    Digit(#(5, 6), "b", 0xB),
+    Digit(#(6, 7), "e", 0xE),
+    Digit(#(7, 8), "e", 0xE),
+    Digit(#(8, 9), "f", 0xF),
+    Digit(#(9, 10), "Z", 35),
   ])
 }
 
@@ -108,42 +109,42 @@ pub fn tokenize_int_base_35_test() {
   "1234567890abcdefghijklmnopqrstuvwxyz"
   |> tokenizer.tokenize_int(base: 35)
   |> expect.to_equal([
-    Digit(#(0, 1), "1", 1, 35),
-    Digit(#(1, 2), "2", 2, 35),
-    Digit(#(2, 3), "3", 3, 35),
-    Digit(#(3, 4), "4", 4, 35),
-    Digit(#(4, 5), "5", 5, 35),
-    Digit(#(5, 6), "6", 6, 35),
-    Digit(#(6, 7), "7", 7, 35),
-    Digit(#(7, 8), "8", 8, 35),
-    Digit(#(8, 9), "9", 9, 35),
-    Digit(#(9, 10), "0", 0, 35),
-    Digit(#(10, 11), "a", 10, 35),
-    Digit(#(11, 12), "b", 11, 35),
-    Digit(#(12, 13), "c", 12, 35),
-    Digit(#(13, 14), "d", 13, 35),
-    Digit(#(14, 15), "e", 14, 35),
-    Digit(#(15, 16), "f", 15, 35),
-    Digit(#(16, 17), "g", 16, 35),
-    Digit(#(17, 18), "h", 17, 35),
-    Digit(#(18, 19), "i", 18, 35),
-    Digit(#(19, 20), "j", 19, 35),
-    Digit(#(20, 21), "k", 20, 35),
-    Digit(#(21, 22), "l", 21, 35),
-    Digit(#(22, 23), "m", 22, 35),
-    Digit(#(23, 24), "n", 23, 35),
-    Digit(#(24, 25), "o", 24, 35),
-    Digit(#(25, 26), "p", 25, 35),
-    Digit(#(26, 27), "q", 26, 35),
-    Digit(#(27, 28), "r", 27, 35),
-    Digit(#(28, 29), "s", 28, 35),
-    Digit(#(29, 30), "t", 29, 35),
-    Digit(#(30, 31), "u", 30, 35),
-    Digit(#(31, 32), "v", 31, 35),
-    Digit(#(32, 33), "w", 32, 35),
-    Digit(#(33, 34), "x", 33, 35),
-    Digit(#(34, 35), "y", 34, 35),
-    Digit(#(35, 36), "z", 35, 35),
+    Digit(#(0, 1), "1", 1),
+    Digit(#(1, 2), "2", 2),
+    Digit(#(2, 3), "3", 3),
+    Digit(#(3, 4), "4", 4),
+    Digit(#(4, 5), "5", 5),
+    Digit(#(5, 6), "6", 6),
+    Digit(#(6, 7), "7", 7),
+    Digit(#(7, 8), "8", 8),
+    Digit(#(8, 9), "9", 9),
+    Digit(#(9, 10), "0", 0),
+    Digit(#(10, 11), "a", 10),
+    Digit(#(11, 12), "b", 11),
+    Digit(#(12, 13), "c", 12),
+    Digit(#(13, 14), "d", 13),
+    Digit(#(14, 15), "e", 14),
+    Digit(#(15, 16), "f", 15),
+    Digit(#(16, 17), "g", 16),
+    Digit(#(17, 18), "h", 17),
+    Digit(#(18, 19), "i", 18),
+    Digit(#(19, 20), "j", 19),
+    Digit(#(20, 21), "k", 20),
+    Digit(#(21, 22), "l", 21),
+    Digit(#(22, 23), "m", 22),
+    Digit(#(23, 24), "n", 23),
+    Digit(#(24, 25), "o", 24),
+    Digit(#(25, 26), "p", 25),
+    Digit(#(26, 27), "q", 26),
+    Digit(#(27, 28), "r", 27),
+    Digit(#(28, 29), "s", 28),
+    Digit(#(29, 30), "t", 29),
+    Digit(#(30, 31), "u", 30),
+    Digit(#(31, 32), "v", 31),
+    Digit(#(32, 33), "w", 32),
+    Digit(#(33, 34), "x", 33),
+    Digit(#(34, 35), "y", 34),
+    Digit(#(35, 36), "z", 35),
   ])
 }
 
@@ -151,10 +152,145 @@ pub fn tokenize_int_base_36_test() {
   "159az"
   |> tokenizer.tokenize_int(base: 36)
   |> expect.to_equal([
-    Digit(#(0, 1), "1", 1, 36),
-    Digit(#(1, 2), "5", 5, 36),
-    Digit(#(2, 3), "9", 9, 36),
-    Digit(#(3, 4), "a", 10, 36),
-    Digit(#(4, 5), "z", 35, 36),
+    Digit(#(0, 1), "1", 1),
+    Digit(#(1, 2), "5", 5),
+    Digit(#(2, 3), "9", 9),
+    Digit(#(3, 4), "a", 10),
+    Digit(#(4, 5), "z", 35),
+  ])
+}
+
+pub fn tokenize_int_with_0b_prefix_and_base_0_test() {
+  "   0b1010b"
+  |> tokenizer.tokenize_int(base: 0)
+  |> expect.to_equal([
+    Whitespace(#(0, 1), " "),
+    Whitespace(#(1, 2), " "),
+    Whitespace(#(2, 3), " "),
+    BasePrefix(#(3, 5), "0b", 2),
+    Digit(#(5, 6), "1", 1),
+    Digit(#(6, 7), "0", 0),
+    Digit(#(7, 8), "1", 1),
+    Digit(#(8, 9), "0", 0),
+    Digit(#(9, 10), "b", 11),
+  ])
+}
+
+pub fn tokenize_int_with_0o_prefix_and_base_0_test() {
+  "   0o0123456780o"
+  |> tokenizer.tokenize_int(base: 0)
+  |> expect.to_equal([
+    Whitespace(#(0, 1), " "),
+    Whitespace(#(1, 2), " "),
+    Whitespace(#(2, 3), " "),
+    BasePrefix(#(3, 5), "0o", 8),
+    Digit(#(5, 6), "0", 0),
+    Digit(#(6, 7), "1", 1),
+    Digit(#(7, 8), "2", 2),
+    Digit(#(8, 9), "3", 3),
+    Digit(#(9, 10), "4", 4),
+    Digit(#(10, 11), "5", 5),
+    Digit(#(11, 12), "6", 6),
+    Digit(#(12, 13), "7", 7),
+    Digit(#(13, 14), "8", 8),
+    Digit(#(14, 15), "0", 0),
+    Digit(#(15, 16), "o", 24),
+  ])
+}
+
+pub fn tokenize_int_with_0x_prefix_and_base_0_test() {
+  " +0XDEAD_BEEF0x "
+  |> tokenizer.tokenize_int(base: 0)
+  |> expect.to_equal([
+    Whitespace(#(0, 1), " "),
+    Sign(#(1, 2), "+", True),
+    BasePrefix(#(2, 4), "0X", 16),
+    Digit(#(4, 5), "D", 13),
+    Digit(#(5, 6), "E", 14),
+    Digit(#(6, 7), "A", 10),
+    Digit(#(7, 8), "D", 13),
+    Underscore(#(8, 9)),
+    Digit(#(9, 10), "B", 11),
+    Digit(#(10, 11), "E", 14),
+    Digit(#(11, 12), "E", 14),
+    Digit(#(12, 13), "F", 15),
+    Digit(#(13, 14), "0", 0),
+    Digit(#(14, 15), "x", 33),
+    Whitespace(#(15, 16), " "),
+  ])
+}
+
+pub fn tokenize_int_with_no_prefix_and_base_0_test() {
+  "  \n+1990_04_12.0e4 "
+  |> tokenizer.tokenize_int(base: 0)
+  |> expect.to_equal([
+    Whitespace(#(0, 1), " "),
+    Whitespace(#(1, 2), " "),
+    Whitespace(#(2, 3), "\n"),
+    Sign(#(3, 4), "+", True),
+    Digit(#(4, 5), "1", 1),
+    Digit(#(5, 6), "9", 9),
+    Digit(#(6, 7), "9", 9),
+    Digit(#(7, 8), "0", 0),
+    Underscore(#(8, 9)),
+    Digit(#(9, 10), "0", 0),
+    Digit(#(10, 11), "4", 4),
+    Underscore(#(11, 12)),
+    Digit(#(12, 13), "1", 1),
+    Digit(#(13, 14), "2", 2),
+    Unknown(#(14, 15), "."),
+    Digit(#(15, 16), "0", 0),
+    Digit(#(16, 17), "e", 14),
+    Digit(#(17, 18), "4", 4),
+    Whitespace(#(18, 19), " "),
+  ])
+}
+
+pub fn tokenize_int_with_0b_prefix_and_base_2_test() {
+  "   0b1010 a"
+  |> tokenizer.tokenize_int(base: 2)
+  |> expect.to_equal([
+    Whitespace(#(0, 1), " "),
+    Whitespace(#(1, 2), " "),
+    Whitespace(#(2, 3), " "),
+    BasePrefix(#(3, 5), "0b", 2),
+    Digit(#(5, 6), "1", 1),
+    Digit(#(6, 7), "0", 0),
+    Digit(#(7, 8), "1", 1),
+    Digit(#(8, 9), "0", 0),
+    Whitespace(#(9, 10), " "),
+    Digit(#(10, 11), "a", 10),
+  ])
+}
+
+pub fn tokenize_int_with_0o_prefix_and_base_8_test() {
+  "   0o77 a"
+  |> tokenizer.tokenize_int(base: 8)
+  |> expect.to_equal([
+    Whitespace(#(0, 1), " "),
+    Whitespace(#(1, 2), " "),
+    Whitespace(#(2, 3), " "),
+    BasePrefix(#(3, 5), "0o", 8),
+    Digit(#(5, 6), "7", 7),
+    Digit(#(6, 7), "7", 7),
+    Whitespace(#(7, 8), " "),
+    Digit(#(8, 9), "a", 10),
+  ])
+}
+
+pub fn tokenize_int_with_0x_prefix_and_base_16_test() {
+  "   0x_ABC ."
+  |> tokenizer.tokenize_int(base: 16)
+  |> expect.to_equal([
+    Whitespace(#(0, 1), " "),
+    Whitespace(#(1, 2), " "),
+    Whitespace(#(2, 3), " "),
+    BasePrefix(#(3, 5), "0x", 16),
+    Underscore(#(5, 6)),
+    Digit(#(6, 7), "A", 10),
+    Digit(#(7, 8), "B", 11),
+    Digit(#(8, 9), "C", 12),
+    Whitespace(#(9, 10), " "),
+    Unknown(#(10, 11), "."),
   ])
 }


### PR DESCRIPTION
Closes: #44 

Using base 0 in Python's `int()` tells Python to look for specific prefixes:

- [X] `0x` | `0X`: Hexadecimal
- [X] `0b` | `0b`: Binary
- [X] `0o` | `0o`: Octal
- [X] No prefix: Decimal
- [x] All marked TODOs in code

---

- [x] Prefixes should also work when paired with the correct base value:

```sh
>>> int("0b1001", base=2)
9
```

- [x] And error out when the base is specified and the digit characters used exceed the base value

```sh
>>> int("0b1001", base=8)
ValueError: invalid literal for int() with base 2: '0x10101'
```

---

Blocked on:

- https://github.com/JosephTLyons/lenient_parse/issues/41