### PR TITLE
Support fine grained python error comparison

### DIFF
--- a/test/data/float/invalid_float_data.gleam
+++ b/test/data/float/invalid_float_data.gleam
@@ -1,346 +1,380 @@
 import gleam/list
+import helpers
 import parse_error.{
-  EmptyString, InvalidDecimalPosition, InvalidExponentSymbolPosition,
-  InvalidUnderscorePosition, UnknownCharacter, WhitespaceOnlyString,
+  type ParseError, EmptyString, InvalidDecimalPosition,
+  InvalidExponentSymbolPosition, InvalidUnderscorePosition, UnknownCharacter,
+  WhitespaceOnlyString,
 }
+import python/python_error.{type PythonError, ValueError}
 import test_data.{type FloatTestData, FloatTestData}
 
-const invalid_empty_or_whitespace: List(FloatTestData) = [
-  FloatTestData(
-    input: "",
-    expected_program_output: Error(EmptyString),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: " ",
-    expected_program_output: Error(WhitespaceOnlyString),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "\t",
-    expected_program_output: Error(WhitespaceOnlyString),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "\n",
-    expected_program_output: Error(WhitespaceOnlyString),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "\r",
-    expected_program_output: Error(WhitespaceOnlyString),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "\f",
-    expected_program_output: Error(WhitespaceOnlyString),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "\r\n",
-    expected_program_output: Error(WhitespaceOnlyString),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: " \t\n\r\f ",
-    expected_program_output: Error(WhitespaceOnlyString),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "  \t  ",
-    expected_program_output: Error(WhitespaceOnlyString),
-    expected_python_output: Error(Nil),
-  ),
-]
+fn could_not_convert_string_to_float_error(input: String) -> PythonError {
+  let message = "could not convert string to float: '" <> input <> "'"
+  ValueError(message)
+}
 
-const invalid_decimal_position: List(FloatTestData) = [
-  FloatTestData(
-    input: "..1",
-    expected_program_output: Error(InvalidDecimalPosition(0)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "1..",
-    expected_program_output: Error(InvalidDecimalPosition(2)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: ".1.",
-    expected_program_output: Error(InvalidDecimalPosition(2)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: ".",
-    expected_program_output: Error(InvalidDecimalPosition(0)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "..",
-    expected_program_output: Error(InvalidDecimalPosition(0)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: " .",
-    expected_program_output: Error(InvalidDecimalPosition(1)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "1.2.3",
-    expected_program_output: Error(InvalidDecimalPosition(3)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: ".1.2",
-    expected_program_output: Error(InvalidDecimalPosition(2)),
-    expected_python_output: Error(Nil),
-  ),
-]
+fn float_test_data(
+  input input: String,
+  expected_program_output expected_program_output: Result(Float, ParseError),
+  python_error_function python_error_function: fn(String) -> PythonError,
+) -> FloatTestData {
+  let printable_text = input |> helpers.to_printable_text(True)
 
-const invalid_underscore_position: List(FloatTestData) = [
   FloatTestData(
-    input: "_.",
-    expected_program_output: Error(InvalidUnderscorePosition(0)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "._",
-    expected_program_output: Error(InvalidUnderscorePosition(1)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "1_.000",
-    expected_program_output: Error(InvalidUnderscorePosition(1)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "1._000",
-    expected_program_output: Error(InvalidUnderscorePosition(2)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "_1000.0",
-    expected_program_output: Error(InvalidUnderscorePosition(0)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "1000.0_",
-    expected_program_output: Error(InvalidUnderscorePosition(6)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "1000._0",
-    expected_program_output: Error(InvalidUnderscorePosition(5)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "1000_.0",
-    expected_program_output: Error(InvalidUnderscorePosition(4)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "1000_.",
-    expected_program_output: Error(InvalidUnderscorePosition(4)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "1_000__000.0",
-    expected_program_output: Error(InvalidUnderscorePosition(6)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "_1_000.0",
-    expected_program_output: Error(InvalidUnderscorePosition(0)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "1_000.0_",
-    expected_program_output: Error(InvalidUnderscorePosition(7)),
-    expected_python_output: Error(Nil),
-  ),
-]
+    input: input,
+    expected_program_output: expected_program_output,
+    expected_python_output: Error(python_error_function(printable_text)),
+  )
+}
 
-const unknown_character: List(FloatTestData) = [
-  FloatTestData(
-    input: ". ",
-    expected_program_output: Error(UnknownCharacter(1, " ")),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "abc",
-    expected_program_output: Error(UnknownCharacter(0, "a")),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "100.00c01",
-    expected_program_output: Error(UnknownCharacter(6, "c")),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "3.14f",
-    expected_program_output: Error(UnknownCharacter(4, "f")),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "$100.00",
-    expected_program_output: Error(UnknownCharacter(0, "$")),
-    expected_python_output: Error(Nil),
-  ),
-]
+fn invalid_empty_or_whitespace() -> List(FloatTestData) {
+  [
+    float_test_data(
+      input: "",
+      expected_program_output: Error(EmptyString),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: " ",
+      expected_program_output: Error(WhitespaceOnlyString),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "\t",
+      expected_program_output: Error(WhitespaceOnlyString),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "\n",
+      expected_program_output: Error(WhitespaceOnlyString),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "\r",
+      expected_program_output: Error(WhitespaceOnlyString),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "\f",
+      expected_program_output: Error(WhitespaceOnlyString),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "\r\n",
+      expected_program_output: Error(WhitespaceOnlyString),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: " \t\n\r\f ",
+      expected_program_output: Error(WhitespaceOnlyString),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "  \t  ",
+      expected_program_output: Error(WhitespaceOnlyString),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+  ]
+}
 
-const invalid_exponent_symbol_position: List(FloatTestData) = [
-  FloatTestData(
-    input: "e",
-    expected_program_output: Error(InvalidExponentSymbolPosition(0, "e")),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "E",
-    expected_program_output: Error(InvalidExponentSymbolPosition(0, "E")),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "e4",
-    expected_program_output: Error(InvalidExponentSymbolPosition(0, "e")),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "E4",
-    expected_program_output: Error(InvalidExponentSymbolPosition(0, "E")),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "4e",
-    expected_program_output: Error(InvalidExponentSymbolPosition(1, "e")),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "4E",
-    expected_program_output: Error(InvalidExponentSymbolPosition(1, "E")),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "4.e",
-    expected_program_output: Error(InvalidExponentSymbolPosition(2, "e")),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "4.E",
-    expected_program_output: Error(InvalidExponentSymbolPosition(2, "E")),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "4e.",
-    expected_program_output: Error(InvalidExponentSymbolPosition(1, "e")),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "4E.",
-    expected_program_output: Error(InvalidExponentSymbolPosition(1, "E")),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "E4.0",
-    expected_program_output: Error(InvalidExponentSymbolPosition(0, "E")),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "4.0E",
-    expected_program_output: Error(InvalidExponentSymbolPosition(3, "E")),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "1_234.e-4e",
-    expected_program_output: Error(InvalidExponentSymbolPosition(9, "e")),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "1e2e3",
-    expected_program_output: Error(InvalidExponentSymbolPosition(3, "e")),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "1E2E3",
-    expected_program_output: Error(InvalidExponentSymbolPosition(3, "E")),
-    expected_python_output: Error(Nil),
-  ),
-]
+fn invalid_decimal_position() -> List(FloatTestData) {
+  [
+    float_test_data(
+      input: "..1",
+      expected_program_output: Error(InvalidDecimalPosition(0)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "1..",
+      expected_program_output: Error(InvalidDecimalPosition(2)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: ".1.",
+      expected_program_output: Error(InvalidDecimalPosition(2)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: ".",
+      expected_program_output: Error(InvalidDecimalPosition(0)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "..",
+      expected_program_output: Error(InvalidDecimalPosition(0)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: " .",
+      expected_program_output: Error(InvalidDecimalPosition(1)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "1.2.3",
+      expected_program_output: Error(InvalidDecimalPosition(3)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: ".1.2",
+      expected_program_output: Error(InvalidDecimalPosition(2)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+  ]
+}
 
-const invalid_mixed: List(FloatTestData) = [
-  FloatTestData(
-    input: "4.0E_2",
-    expected_program_output: Error(InvalidUnderscorePosition(4)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "1.2e_3",
-    expected_program_output: Error(InvalidUnderscorePosition(4)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "4.0_E2",
-    expected_program_output: Error(InvalidUnderscorePosition(3)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "1_234.e-4.3",
-    expected_program_output: Error(InvalidDecimalPosition(9)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "_1.2e3",
-    expected_program_output: Error(InvalidUnderscorePosition(0)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "1.2e3_",
-    expected_program_output: Error(InvalidUnderscorePosition(5)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: ".e",
-    expected_program_output: Error(InvalidDecimalPosition(0)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: ".E",
-    expected_program_output: Error(InvalidDecimalPosition(0)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: ".e4",
-    expected_program_output: Error(InvalidDecimalPosition(0)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: ".E4",
-    expected_program_output: Error(InvalidDecimalPosition(0)),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: " 4.0E",
-    expected_program_output: Error(InvalidExponentSymbolPosition(4, "E")),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: "4.0E ",
-    expected_program_output: Error(UnknownCharacter(4, " ")),
-    expected_python_output: Error(Nil),
-  ),
-  FloatTestData(
-    input: " 4.0E ",
-    expected_program_output: Error(UnknownCharacter(5, " ")),
-    expected_python_output: Error(Nil),
-  ),
-]
+fn invalid_underscore_position() -> List(FloatTestData) {
+  [
+    float_test_data(
+      input: "_.",
+      expected_program_output: Error(InvalidUnderscorePosition(0)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "._",
+      expected_program_output: Error(InvalidUnderscorePosition(1)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "1_.000",
+      expected_program_output: Error(InvalidUnderscorePosition(1)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "1._000",
+      expected_program_output: Error(InvalidUnderscorePosition(2)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "_1000.0",
+      expected_program_output: Error(InvalidUnderscorePosition(0)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "1000.0_",
+      expected_program_output: Error(InvalidUnderscorePosition(6)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "1000._0",
+      expected_program_output: Error(InvalidUnderscorePosition(5)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "1000_.0",
+      expected_program_output: Error(InvalidUnderscorePosition(4)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "1000_.",
+      expected_program_output: Error(InvalidUnderscorePosition(4)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "1_000__000.0",
+      expected_program_output: Error(InvalidUnderscorePosition(6)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "_1_000.0",
+      expected_program_output: Error(InvalidUnderscorePosition(0)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "1_000.0_",
+      expected_program_output: Error(InvalidUnderscorePosition(7)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+  ]
+}
+
+fn unknown_character() -> List(FloatTestData) {
+  [
+    float_test_data(
+      input: ". ",
+      expected_program_output: Error(UnknownCharacter(1, " ")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "abc",
+      expected_program_output: Error(UnknownCharacter(0, "a")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "100.00c01",
+      expected_program_output: Error(UnknownCharacter(6, "c")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "3.14f",
+      expected_program_output: Error(UnknownCharacter(4, "f")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "$100.00",
+      expected_program_output: Error(UnknownCharacter(0, "$")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+  ]
+}
+
+fn invalid_exponent_symbol_position() -> List(FloatTestData) {
+  [
+    float_test_data(
+      input: "e",
+      expected_program_output: Error(InvalidExponentSymbolPosition(0, "e")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "E",
+      expected_program_output: Error(InvalidExponentSymbolPosition(0, "E")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "e4",
+      expected_program_output: Error(InvalidExponentSymbolPosition(0, "e")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "E4",
+      expected_program_output: Error(InvalidExponentSymbolPosition(0, "E")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "4e",
+      expected_program_output: Error(InvalidExponentSymbolPosition(1, "e")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "4E",
+      expected_program_output: Error(InvalidExponentSymbolPosition(1, "E")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "4.e",
+      expected_program_output: Error(InvalidExponentSymbolPosition(2, "e")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "4.E",
+      expected_program_output: Error(InvalidExponentSymbolPosition(2, "E")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "4e.",
+      expected_program_output: Error(InvalidExponentSymbolPosition(1, "e")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "4E.",
+      expected_program_output: Error(InvalidExponentSymbolPosition(1, "E")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "E4.0",
+      expected_program_output: Error(InvalidExponentSymbolPosition(0, "E")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "4.0E",
+      expected_program_output: Error(InvalidExponentSymbolPosition(3, "E")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "1_234.e-4e",
+      expected_program_output: Error(InvalidExponentSymbolPosition(9, "e")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "1e2e3",
+      expected_program_output: Error(InvalidExponentSymbolPosition(3, "e")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "1E2E3",
+      expected_program_output: Error(InvalidExponentSymbolPosition(3, "E")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+  ]
+}
+
+fn invalid_mixed() -> List(FloatTestData) {
+  [
+    float_test_data(
+      input: "4.0E_2",
+      expected_program_output: Error(InvalidUnderscorePosition(4)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "1.2e_3",
+      expected_program_output: Error(InvalidUnderscorePosition(4)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "4.0_E2",
+      expected_program_output: Error(InvalidUnderscorePosition(3)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "1_234.e-4.3",
+      expected_program_output: Error(InvalidDecimalPosition(9)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "_1.2e3",
+      expected_program_output: Error(InvalidUnderscorePosition(0)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "1.2e3_",
+      expected_program_output: Error(InvalidUnderscorePosition(5)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: ".e",
+      expected_program_output: Error(InvalidDecimalPosition(0)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: ".E",
+      expected_program_output: Error(InvalidDecimalPosition(0)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: ".e4",
+      expected_program_output: Error(InvalidDecimalPosition(0)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: ".E4",
+      expected_program_output: Error(InvalidDecimalPosition(0)),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: " 4.0E",
+      expected_program_output: Error(InvalidExponentSymbolPosition(4, "E")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: "4.0E ",
+      expected_program_output: Error(UnknownCharacter(4, " ")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+    float_test_data(
+      input: " 4.0E ",
+      expected_program_output: Error(UnknownCharacter(5, " ")),
+      python_error_function: could_not_convert_string_to_float_error,
+    ),
+  ]
+}
 
 pub fn data() -> List(FloatTestData) {
   [
-    invalid_empty_or_whitespace,
-    invalid_decimal_position,
-    invalid_underscore_position,
-    unknown_character,
-    invalid_exponent_symbol_position,
-    invalid_mixed,
+    invalid_empty_or_whitespace(),
+    invalid_decimal_position(),
+    invalid_underscore_position(),
+    unknown_character(),
+    invalid_exponent_symbol_position(),
+    invalid_mixed(),
   ]
   |> list.flatten
 }

--- a/test/data/integer/invalid_integer_data.gleam
+++ b/test/data/integer/invalid_integer_data.gleam
@@ -13,6 +13,7 @@ import test_data.{type IntegerTestData, IntegerTestData}
 // TODO: Add direct testing of sending in a handful of error values into python and asserting we are constructing correct records
 // TODO: Can we analyze the Exception and form a structured json string within Python that we can more safely deserialize, over a regex?
 //    Include exception type (ValueError), message, and values that are injected into the message? If possible
+// TODO: Should each test data define Error() rathter than generically constructing it in the error function?
 
 fn invalid_literal_for_int_error(input: String, base: Int) -> PythonError {
   let message =

--- a/test/data/integer/invalid_integer_data.gleam
+++ b/test/data/integer/invalid_integer_data.gleam
@@ -1,500 +1,557 @@
+import gleam/int
 import gleam/list
+import helpers
 import parse_error.{
-  BasePrefixOnly, EmptyString, InvalidBaseValue, InvalidDigitPosition,
-  InvalidSignPosition, InvalidUnderscorePosition, OutOfBaseRange,
-  UnknownCharacter, WhitespaceOnlyString,
+  type ParseError, BasePrefixOnly, EmptyString, InvalidBaseValue,
+  InvalidDigitPosition, InvalidSignPosition, InvalidUnderscorePosition,
+  OutOfBaseRange, UnknownCharacter, WhitespaceOnlyString,
 }
+import python/python_error.{type PythonError, ValueError}
 import test_data.{type IntegerTestData, IntegerTestData}
 
-const invalid_empty_or_whitespace: List(IntegerTestData) = [
-  IntegerTestData(
-    input: "",
-    base: 10,
-    expected_program_output: Error(EmptyString),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: " ",
-    base: 10,
-    expected_program_output: Error(WhitespaceOnlyString),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "\t",
-    base: 10,
-    expected_program_output: Error(WhitespaceOnlyString),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "\n",
-    base: 10,
-    expected_program_output: Error(WhitespaceOnlyString),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "\r",
-    base: 10,
-    expected_program_output: Error(WhitespaceOnlyString),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "\f",
-    base: 10,
-    expected_program_output: Error(WhitespaceOnlyString),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "\r\n",
-    base: 10,
-    expected_program_output: Error(WhitespaceOnlyString),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: " \t\n\r\f\r\n ",
-    base: 10,
-    expected_program_output: Error(WhitespaceOnlyString),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "   ",
-    base: 10,
-    expected_program_output: Error(WhitespaceOnlyString),
-    expected_python_output: Error(Nil),
-  ),
-]
+// TODO: PythonError into structured data via a regex?
+// TODO: Add direct testing of sending in a handful of error values into python and asserting we are constructing correct records
+// TODO: Can we analyze the Exception and form a structured json string within Python that we can more safely deserialize, over a regex?
+//    Include exception type (ValueError), message, and values that are injected into the message? If possible
 
-const invalid_underscore_position: List(IntegerTestData) = [
-  IntegerTestData(
-    input: "_",
-    base: 10,
-    expected_program_output: Error(InvalidUnderscorePosition(0)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "_1000",
-    base: 10,
-    expected_program_output: Error(InvalidUnderscorePosition(0)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "1000_",
-    base: 10,
-    expected_program_output: Error(InvalidUnderscorePosition(4)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: " _1000",
-    base: 10,
-    expected_program_output: Error(InvalidUnderscorePosition(1)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "1000_ ",
-    base: 10,
-    expected_program_output: Error(InvalidUnderscorePosition(4)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "+_1000",
-    base: 10,
-    expected_program_output: Error(InvalidUnderscorePosition(1)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "-_1000",
-    base: 10,
-    expected_program_output: Error(InvalidUnderscorePosition(1)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "1__000",
-    base: 10,
-    expected_program_output: Error(InvalidUnderscorePosition(2)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "1_000__000",
-    base: 10,
-    expected_program_output: Error(InvalidUnderscorePosition(6)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "_1_000",
-    base: 10,
-    expected_program_output: Error(InvalidUnderscorePosition(0)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "1_000_",
-    base: 10,
-    expected_program_output: Error(InvalidUnderscorePosition(5)),
-    expected_python_output: Error(Nil),
-  ),
-]
+fn invalid_literal_for_int_error(input: String, base: Int) -> PythonError {
+  let message =
+    "invalid literal for int() with base "
+    <> base |> int.to_string
+    <> ": '"
+    <> input
+    <> "'"
 
-const unknown_character: List(IntegerTestData) = [
-  IntegerTestData(
-    input: "+ 1",
-    base: 10,
-    expected_program_output: Error(UnknownCharacter(1, " ")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: ".",
-    base: 10,
-    expected_program_output: Error(UnknownCharacter(0, ".")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "..",
-    base: 10,
-    expected_program_output: Error(UnknownCharacter(0, ".")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "0.0.",
-    base: 10,
-    expected_program_output: Error(UnknownCharacter(1, ".")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: ".0.0",
-    base: 10,
-    expected_program_output: Error(UnknownCharacter(0, ".")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "1.",
-    base: 10,
-    expected_program_output: Error(UnknownCharacter(1, ".")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "1.0",
-    base: 10,
-    expected_program_output: Error(UnknownCharacter(1, ".")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "1$",
-    base: 10,
-    expected_program_output: Error(UnknownCharacter(1, "$")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "#123",
-    base: 10,
-    expected_program_output: Error(UnknownCharacter(0, "#")),
-    expected_python_output: Error(Nil),
-  ),
-]
+  ValueError(message)
+}
 
-const out_of_base_range: List(IntegerTestData) = [
-  IntegerTestData(
-    input: "a",
-    base: 10,
-    expected_program_output: Error(OutOfBaseRange(0, "a", 10, 10)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "1b1",
-    base: 10,
-    expected_program_output: Error(OutOfBaseRange(1, "b", 11, 10)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "abc",
-    base: 10,
-    expected_program_output: Error(OutOfBaseRange(0, "a", 10, 10)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "e",
-    base: 10,
-    expected_program_output: Error(OutOfBaseRange(0, "e", 14, 10)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "E",
-    base: 10,
-    expected_program_output: Error(OutOfBaseRange(0, "E", 14, 10)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "e13",
-    base: 10,
-    expected_program_output: Error(OutOfBaseRange(0, "e", 14, 10)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "1e3",
-    base: 10,
-    expected_program_output: Error(OutOfBaseRange(1, "e", 14, 10)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "13e",
-    base: 10,
-    expected_program_output: Error(OutOfBaseRange(2, "e", 14, 10)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "E13",
-    base: 10,
-    expected_program_output: Error(OutOfBaseRange(0, "E", 14, 10)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "1E3",
-    base: 10,
-    expected_program_output: Error(OutOfBaseRange(1, "E", 14, 10)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "13E",
-    base: 10,
-    expected_program_output: Error(OutOfBaseRange(2, "E", 14, 10)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "151",
-    base: 2,
-    expected_program_output: Error(OutOfBaseRange(1, "5", 5, 2)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "DEAD_BEEF",
-    base: 10,
-    expected_program_output: Error(OutOfBaseRange(0, "D", 13, 10)),
-    expected_python_output: Error(Nil),
-  ),
-]
+fn invalid_base_value_error(_: String, _: Int) -> PythonError {
+  ValueError("int() base must be >= 2 and <= 36, or 0")
+}
 
-const invalid_digit_position: List(IntegerTestData) = [
-  IntegerTestData(
-    input: "1 1",
-    base: 10,
-    expected_program_output: Error(InvalidDigitPosition(2, "1")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: " 12 34 ",
-    base: 10,
-    expected_program_output: Error(InvalidDigitPosition(4, "3")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "1 2 3",
-    base: 10,
-    expected_program_output: Error(InvalidDigitPosition(2, "2")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "123 456",
-    base: 10,
-    expected_program_output: Error(InvalidDigitPosition(4, "4")),
-    expected_python_output: Error(Nil),
-  ),
-]
+fn integer_test_data(
+  input input: String,
+  base base: Int,
+  expected_program_output expected_program_output: Result(Int, ParseError),
+  python_error_function python_error_function: fn(String, Int) -> PythonError,
+) -> IntegerTestData {
+  let printable_text = input |> helpers.to_printable_text(True)
 
-const invalid_sign_position: List(IntegerTestData) = [
   IntegerTestData(
-    input: "1+",
-    base: 10,
-    expected_program_output: Error(InvalidSignPosition(1, "+")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "1-",
-    base: 10,
-    expected_program_output: Error(InvalidSignPosition(1, "-")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "1+1",
-    base: 10,
-    expected_program_output: Error(InvalidSignPosition(1, "+")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "1-1",
-    base: 10,
-    expected_program_output: Error(InvalidSignPosition(1, "-")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "++1",
-    base: 10,
-    expected_program_output: Error(InvalidSignPosition(1, "+")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "--1",
-    base: 10,
-    expected_program_output: Error(InvalidSignPosition(1, "-")),
-    expected_python_output: Error(Nil),
-  ),
-]
+    input: input,
+    base: base,
+    expected_program_output: expected_program_output,
+    expected_python_output: Error(python_error_function(printable_text, base)),
+  )
+}
 
-const invalid_base_value: List(IntegerTestData) = [
-  IntegerTestData(
-    input: "151",
-    base: 1,
-    expected_program_output: Error(InvalidBaseValue(1)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "151",
-    base: 37,
-    expected_program_output: Error(InvalidBaseValue(37)),
-    expected_python_output: Error(Nil),
-  ),
-]
+fn invalid_empty_or_whitespace() -> List(IntegerTestData) {
+  [
+    integer_test_data(
+      input: "",
+      base: 10,
+      expected_program_output: Error(EmptyString),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: " ",
+      base: 10,
+      expected_program_output: Error(WhitespaceOnlyString),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "\t",
+      base: 10,
+      expected_program_output: Error(WhitespaceOnlyString),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "\n",
+      base: 10,
+      expected_program_output: Error(WhitespaceOnlyString),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "\r",
+      base: 10,
+      expected_program_output: Error(WhitespaceOnlyString),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "\f",
+      base: 10,
+      expected_program_output: Error(WhitespaceOnlyString),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "\r\n",
+      base: 10,
+      expected_program_output: Error(WhitespaceOnlyString),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: " \t\n\r\f\r\n ",
+      base: 10,
+      expected_program_output: Error(WhitespaceOnlyString),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "   ",
+      base: 10,
+      expected_program_output: Error(WhitespaceOnlyString),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+  ]
+}
 
-const base_prefix_only: List(IntegerTestData) = [
-  IntegerTestData(
-    input: "  0b",
-    base: 0,
-    expected_program_output: Error(BasePrefixOnly(#(2, 4), "0b")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "  0b  ",
-    base: 0,
-    expected_program_output: Error(UnknownCharacter(4, " ")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "0b100b",
-    base: 0,
-    expected_program_output: Error(OutOfBaseRange(5, "b", 11, 2)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "0b1001",
-    base: 8,
-    expected_program_output: Error(OutOfBaseRange(1, "b", 11, 8)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "0XABCD",
-    base: 2,
-    expected_program_output: Error(OutOfBaseRange(1, "X", 33, 2)),
-    expected_python_output: Error(Nil),
-  ),
-]
+fn invalid_underscore_position() -> List(IntegerTestData) {
+  [
+    integer_test_data(
+      input: "_",
+      base: 10,
+      expected_program_output: Error(InvalidUnderscorePosition(0)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "_1000",
+      base: 10,
+      expected_program_output: Error(InvalidUnderscorePosition(0)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1000_",
+      base: 10,
+      expected_program_output: Error(InvalidUnderscorePosition(4)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: " _1000",
+      base: 10,
+      expected_program_output: Error(InvalidUnderscorePosition(1)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1000_ ",
+      base: 10,
+      expected_program_output: Error(InvalidUnderscorePosition(4)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "+_1000",
+      base: 10,
+      expected_program_output: Error(InvalidUnderscorePosition(1)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "-_1000",
+      base: 10,
+      expected_program_output: Error(InvalidUnderscorePosition(1)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1__000",
+      base: 10,
+      expected_program_output: Error(InvalidUnderscorePosition(2)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1_000__000",
+      base: 10,
+      expected_program_output: Error(InvalidUnderscorePosition(6)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "_1_000",
+      base: 10,
+      expected_program_output: Error(InvalidUnderscorePosition(0)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1_000_",
+      base: 10,
+      expected_program_output: Error(InvalidUnderscorePosition(5)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+  ]
+}
 
-const invalid_mixed: List(IntegerTestData) = [
-  IntegerTestData(
-    input: "e_1_3",
-    base: 10,
-    expected_program_output: Error(OutOfBaseRange(0, "e", 14, 10)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "1_3_e",
-    base: 10,
-    expected_program_output: Error(OutOfBaseRange(4, "e", 14, 10)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "1._3_e",
-    base: 10,
-    expected_program_output: Error(UnknownCharacter(1, ".")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "1+._3_e",
-    base: 10,
-    expected_program_output: Error(InvalidSignPosition(1, "+")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "1 1+._3_e",
-    base: 10,
-    expected_program_output: Error(InvalidDigitPosition(2, "1")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "1_a_2",
-    base: 10,
-    expected_program_output: Error(OutOfBaseRange(2, "a", 10, 10)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "+1.2_3",
-    base: 10,
-    expected_program_output: Error(UnknownCharacter(2, ".")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "  1_f_1  ",
-    base: 2,
-    expected_program_output: Error(OutOfBaseRange(4, "f", 15, 2)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "  1._5_1  ",
-    base: 2,
-    expected_program_output: Error(UnknownCharacter(3, ".")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "  1_1__1  ",
-    base: 2,
-    expected_program_output: Error(InvalidUnderscorePosition(6)),
-    expected_python_output: Error(Nil),
-  ),
-  // Base 0, has no prefix, default to decimal, but error because of UnknownCharacter
-  IntegerTestData(
-    input: " \n6_666.",
-    base: 0,
-    expected_program_output: Error(UnknownCharacter(7, ".")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: " \n0x ABC.",
-    base: 0,
-    expected_program_output: Error(UnknownCharacter(4, " ")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: " \n0xA BC.",
-    base: 0,
-    expected_program_output: Error(InvalidDigitPosition(6, "B")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: " \n0b101 1",
-    base: 0,
-    expected_program_output: Error(InvalidDigitPosition(8, "1")),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "0xDEAD_BEEF_",
-    base: 0,
-    expected_program_output: Error(InvalidUnderscorePosition(11)),
-    expected_python_output: Error(Nil),
-  ),
-  IntegerTestData(
-    input: "_0xDEAD_BEEF",
-    base: 0,
-    expected_program_output: Error(InvalidUnderscorePosition(0)),
-    expected_python_output: Error(Nil),
-  ),
-]
+fn unknown_characters() -> List(IntegerTestData) {
+  [
+    integer_test_data(
+      input: "+ 1",
+      base: 10,
+      expected_program_output: Error(UnknownCharacter(1, " ")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: ".",
+      base: 10,
+      expected_program_output: Error(UnknownCharacter(0, ".")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "..",
+      base: 10,
+      expected_program_output: Error(UnknownCharacter(0, ".")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "0.0.",
+      base: 10,
+      expected_program_output: Error(UnknownCharacter(1, ".")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: ".0.0",
+      base: 10,
+      expected_program_output: Error(UnknownCharacter(0, ".")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1.",
+      base: 10,
+      expected_program_output: Error(UnknownCharacter(1, ".")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1.0",
+      base: 10,
+      expected_program_output: Error(UnknownCharacter(1, ".")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1$",
+      base: 10,
+      expected_program_output: Error(UnknownCharacter(1, "$")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "#123",
+      base: 10,
+      expected_program_output: Error(UnknownCharacter(0, "#")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+  ]
+}
+
+fn out_of_base_range() -> List(IntegerTestData) {
+  [
+    integer_test_data(
+      input: "a",
+      base: 10,
+      expected_program_output: Error(OutOfBaseRange(0, "a", 10, 10)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1b1",
+      base: 10,
+      expected_program_output: Error(OutOfBaseRange(1, "b", 11, 10)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "abc",
+      base: 10,
+      expected_program_output: Error(OutOfBaseRange(0, "a", 10, 10)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "e",
+      base: 10,
+      expected_program_output: Error(OutOfBaseRange(0, "e", 14, 10)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "E",
+      base: 10,
+      expected_program_output: Error(OutOfBaseRange(0, "E", 14, 10)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "e13",
+      base: 10,
+      expected_program_output: Error(OutOfBaseRange(0, "e", 14, 10)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1e3",
+      base: 10,
+      expected_program_output: Error(OutOfBaseRange(1, "e", 14, 10)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "13e",
+      base: 10,
+      expected_program_output: Error(OutOfBaseRange(2, "e", 14, 10)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "E13",
+      base: 10,
+      expected_program_output: Error(OutOfBaseRange(0, "E", 14, 10)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1E3",
+      base: 10,
+      expected_program_output: Error(OutOfBaseRange(1, "E", 14, 10)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "13E",
+      base: 10,
+      expected_program_output: Error(OutOfBaseRange(2, "E", 14, 10)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "151",
+      base: 2,
+      expected_program_output: Error(OutOfBaseRange(1, "5", 5, 2)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "DEAD_BEEF",
+      base: 10,
+      expected_program_output: Error(OutOfBaseRange(0, "D", 13, 10)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+  ]
+}
+
+fn invalid_digit_position() -> List(IntegerTestData) {
+  [
+    integer_test_data(
+      input: "1 1",
+      base: 10,
+      expected_program_output: Error(InvalidDigitPosition(2, "1")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: " 12 34 ",
+      base: 10,
+      expected_program_output: Error(InvalidDigitPosition(4, "3")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1 2 3",
+      base: 10,
+      expected_program_output: Error(InvalidDigitPosition(2, "2")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "123 456",
+      base: 10,
+      expected_program_output: Error(InvalidDigitPosition(4, "4")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+  ]
+}
+
+fn invalid_sign_position() -> List(IntegerTestData) {
+  [
+    integer_test_data(
+      input: "1+",
+      base: 10,
+      expected_program_output: Error(InvalidSignPosition(1, "+")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1-",
+      base: 10,
+      expected_program_output: Error(InvalidSignPosition(1, "-")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1+1",
+      base: 10,
+      expected_program_output: Error(InvalidSignPosition(1, "+")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1-1",
+      base: 10,
+      expected_program_output: Error(InvalidSignPosition(1, "-")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "++1",
+      base: 10,
+      expected_program_output: Error(InvalidSignPosition(1, "+")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "--1",
+      base: 10,
+      expected_program_output: Error(InvalidSignPosition(1, "-")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+  ]
+}
+
+fn invalid_base_value() -> List(IntegerTestData) {
+  [
+    integer_test_data(
+      input: "151",
+      base: 1,
+      expected_program_output: Error(InvalidBaseValue(1)),
+      python_error_function: invalid_base_value_error,
+    ),
+    integer_test_data(
+      input: "151",
+      base: 37,
+      expected_program_output: Error(InvalidBaseValue(37)),
+      python_error_function: invalid_base_value_error,
+    ),
+  ]
+}
+
+fn base_prefix_only() -> List(IntegerTestData) {
+  [
+    integer_test_data(
+      input: "  0b",
+      base: 0,
+      expected_program_output: Error(BasePrefixOnly(#(2, 4), "0b")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "  0b  ",
+      base: 0,
+      expected_program_output: Error(UnknownCharacter(4, " ")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "0b100b",
+      base: 0,
+      expected_program_output: Error(OutOfBaseRange(5, "b", 11, 2)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "0b1001",
+      base: 8,
+      expected_program_output: Error(OutOfBaseRange(1, "b", 11, 8)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "0XABCD",
+      base: 2,
+      expected_program_output: Error(OutOfBaseRange(1, "X", 33, 2)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+  ]
+}
+
+fn invalid_mixed() -> List(IntegerTestData) {
+  [
+    integer_test_data(
+      input: "e_1_3",
+      base: 10,
+      expected_program_output: Error(OutOfBaseRange(0, "e", 14, 10)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1_3_e",
+      base: 10,
+      expected_program_output: Error(OutOfBaseRange(4, "e", 14, 10)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1._3_e",
+      base: 10,
+      expected_program_output: Error(UnknownCharacter(1, ".")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1+._3_e",
+      base: 10,
+      expected_program_output: Error(InvalidSignPosition(1, "+")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1 1+._3_e",
+      base: 10,
+      expected_program_output: Error(InvalidDigitPosition(2, "1")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1_a_2",
+      base: 10,
+      expected_program_output: Error(OutOfBaseRange(2, "a", 10, 10)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "+1.2_3",
+      base: 10,
+      expected_program_output: Error(UnknownCharacter(2, ".")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "  1_f_1  ",
+      base: 2,
+      expected_program_output: Error(OutOfBaseRange(4, "f", 15, 2)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "  1._5_1  ",
+      base: 2,
+      expected_program_output: Error(UnknownCharacter(3, ".")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "  1_1__1  ",
+      base: 2,
+      expected_program_output: Error(InvalidUnderscorePosition(6)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    // Base 0, has no prefix, default to decimal, but error because of UnknownCharacter
+    integer_test_data(
+      input: " \n6_666.",
+      base: 0,
+      expected_program_output: Error(UnknownCharacter(7, ".")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: " \n0x ABC.",
+      base: 0,
+      expected_program_output: Error(UnknownCharacter(4, " ")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: " \n0xA BC.",
+      base: 0,
+      expected_program_output: Error(InvalidDigitPosition(6, "B")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: " \n0b101 1",
+      base: 0,
+      expected_program_output: Error(InvalidDigitPosition(8, "1")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "0xDEAD_BEEF_",
+      base: 0,
+      expected_program_output: Error(InvalidUnderscorePosition(11)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "_0xDEAD_BEEF",
+      base: 0,
+      expected_program_output: Error(InvalidUnderscorePosition(0)),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+  ]
+}
 
 pub fn data() -> List(IntegerTestData) {
   [
-    invalid_empty_or_whitespace,
-    invalid_underscore_position,
-    unknown_character,
-    out_of_base_range,
-    invalid_digit_position,
-    invalid_sign_position,
-    invalid_base_value,
-    base_prefix_only,
-    invalid_mixed,
+    invalid_empty_or_whitespace(),
+    invalid_underscore_position(),
+    unknown_characters(),
+    out_of_base_range(),
+    invalid_digit_position(),
+    invalid_sign_position(),
+    invalid_base_value(),
+    base_prefix_only(),
+    invalid_mixed(),
   ]
   |> list.flatten
 }

--- a/test/helpers.gleam
+++ b/test/helpers.gleam
@@ -1,10 +1,18 @@
 import gleam/string
 
-pub fn to_printable_text(text: String) -> String {
-  do_to_printable_text(text |> string.to_graphemes, "")
+pub fn to_printable_text(text: String, python_output: Bool) -> String {
+  do_to_printable_text(
+    characters: text |> string.to_graphemes,
+    python_output: python_output,
+    acc: "",
+  )
 }
 
-fn do_to_printable_text(characters: List(String), acc: String) -> String {
+fn do_to_printable_text(
+  characters characters: List(String),
+  python_output python_output: Bool,
+  acc acc: String,
+) -> String {
   case characters {
     [] -> acc
     [first, ..rest] -> {
@@ -12,11 +20,17 @@ fn do_to_printable_text(characters: List(String), acc: String) -> String {
         "\t" -> "\\t"
         "\n" -> "\\n"
         "\r" -> "\\r"
+        // Python weirdly converts "\f" to "\x0c"
+        "\f" if python_output -> "\\x0c"
         "\f" -> "\\f"
         "\r\n" -> "\\r\\n"
         _ -> first
       }
-      do_to_printable_text(rest, acc <> printable)
+      do_to_printable_text(
+        characters: rest,
+        python_output: python_output,
+        acc: acc <> printable,
+      )
     }
   }
 }

--- a/test/helpers_test.gleam
+++ b/test/helpers_test.gleam
@@ -18,7 +18,27 @@ pub fn to_printable_text_tests() {
       |> list.map(fn(tuple) {
         let #(input, output) = tuple
         use <- it("\"" <> output <> "\"")
-        input |> to_printable_text |> expect.to_equal(output)
+        input |> to_printable_text(False) |> expect.to_equal(output)
+      }),
+  )
+}
+
+pub fn to_printable_text_python_tests() {
+  describe(
+    "should_be_printable_python_text",
+    [
+      #("\t", "\\t"),
+      #("\n", "\\n"),
+      #("\r", "\\r"),
+      #("\f", "\\x0c"),
+      #("\r\n", "\\r\\n"),
+      #("\t\nabc123\r", "\\t\\nabc123\\r"),
+      #("abc123\r\n", "abc123\\r\\n"),
+    ]
+      |> list.map(fn(tuple) {
+        let #(input, output) = tuple
+        use <- it("\"" <> output <> "\"")
+        input |> to_printable_text(True) |> expect.to_equal(output)
       }),
   )
 }

--- a/test/python/parse_floats.py
+++ b/test/python/parse_floats.py
@@ -6,12 +6,12 @@ data_list = json.loads(json_data)
 output_values = []
 
 for item in data_list:
-    text = item["input"]
+    input = item["input"]
 
     try:
-        value = float(text)
-    except ValueError:
-        value = "ValueError"
+        value = float(input)
+    except ValueError as e:
+        value = f"ValueError: {e}"
 
     output_values.append(str(value))
 

--- a/test/python/parse_ints.py
+++ b/test/python/parse_ints.py
@@ -6,13 +6,13 @@ data_list = json.loads(json_data)
 output_values = []
 
 for item in data_list:
-    text = item["input"]
+    input = item["input"]
     base = int(item["base"])
 
     try:
-        value = int(text, base=base)
-    except ValueError:
-        value = "ValueError"
+        value = int(input, base=base)
+    except ValueError as e:
+        value = f"ValueError: {e}"
 
     output_values.append(str(value))
 

--- a/test/python/python_error.gleam
+++ b/test/python/python_error.gleam
@@ -1,0 +1,3 @@
+pub type PythonError {
+  ValueError(message: String)
+}

--- a/test/python/python_parse.gleam
+++ b/test/python/python_parse.gleam
@@ -1,12 +1,13 @@
 import gleam/dynamic
 import gleam/json
 import gleam/list
+import python/python_error.{type PythonError, ValueError}
 import shellout
 import test_data.{type FloatTestData, type IntegerTestData}
 
 pub fn to_floats(
   float_test_data float_test_data: List(FloatTestData),
-) -> List(Result(String, Nil)) {
+) -> List(Result(String, PythonError)) {
   float_test_data
   |> json.array(fn(float_data) {
     json.object([#("input", json.string(float_data.input))])
@@ -17,7 +18,7 @@ pub fn to_floats(
 
 pub fn to_ints(
   integer_test_data integer_test_data: List(IntegerTestData),
-) -> List(Result(String, Nil)) {
+) -> List(Result(String, PythonError)) {
   integer_test_data
   |> json.array(fn(integer_data) {
     json.object([
@@ -32,7 +33,7 @@ pub fn to_ints(
 fn parse(
   input_json_string input_json_string: String,
   program_name program_name: String,
-) -> List(Result(String, Nil)) {
+) -> List(Result(String, PythonError)) {
   let arguments = [
     "run",
     "-p",
@@ -48,10 +49,15 @@ fn parse(
   let assert Ok(parsed_strings) =
     json.decode(output_json_string, dynamic.list(of: dynamic.string))
 
+  // TODO: Use a regex to extract info from each value error string. Will need
+  // to be different per float and int error. Will also need to have different
+  // variants. A ValueError will hold an InvalidLiteralIntError with the
+  // captured strings.
+
   parsed_strings
   |> list.map(fn(value) {
     case value {
-      "ValueError" -> Error(Nil)
+      "ValueError: " <> error_message -> Error(ValueError(error_message))
       _ -> Ok(value)
     }
   })

--- a/test/python_parse_test.gleam
+++ b/test/python_parse_test.gleam
@@ -18,7 +18,7 @@ pub fn check_against_python_tests() {
           let expected_python_output = { data.0 }.expected_python_output
           let actual_python_output = data.1
 
-          let input_printable_text = input |> helpers.to_printable_text
+          let input_printable_text = input |> helpers.to_printable_text(False)
 
           let message = case expected_program_output, expected_python_output {
             Ok(_), Ok(python_output) -> {
@@ -28,16 +28,18 @@ pub fn check_against_python_tests() {
               <> python_output
               <> "\""
             }
-            Error(_), Error(_) -> {
+            Error(_), Error(python_error) -> {
               "should_not_parse: \""
               <> input_printable_text
-              <> "\" -> \"Error\""
+              <> "\" -> \""
+              <> python_error.message
+              <> "\""
             }
-            Ok(output), Error(_) -> {
+            Ok(output), Error(python_error) -> {
               panic as form_panic_message(
                 input_printable_text,
                 output |> float.to_string,
-                "Error",
+                python_error.message,
               )
             }
             Error(output), Ok(python_output) -> {
@@ -65,11 +67,13 @@ pub fn check_against_python_tests() {
           let expected_python_output = { data.0 }.expected_python_output
           let actual_python_output = data.1
 
-          let input_printable_text = input |> helpers.to_printable_text
+          let input_printable_text = input |> helpers.to_printable_text(False)
+
+          // TODO: Fix print logic here
 
           let base_text = case base {
             10 -> ""
-            _ -> "(base: " <> base |> int.to_string <> ")"
+            _ -> "(base: " <> base |> int.to_string <> ") "
           }
 
           let message = case expected_program_output, expected_python_output {
@@ -82,18 +86,20 @@ pub fn check_against_python_tests() {
               <> python_output
               <> "\""
             }
-            Error(_), Error(_) -> {
+            Error(_), Error(python_error) -> {
               "should_not_parse: \""
               <> input_printable_text
               <> "\" "
               <> base_text
-              <> " -> \"Error\""
+              <> "-> \""
+              <> python_error.message
+              <> "\""
             }
-            Ok(output), Error(_) -> {
+            Ok(output), Error(python_error) -> {
               panic as form_panic_message(
                 input_printable_text,
                 output |> int.to_string,
-                "Error",
+                python_error.message,
               )
             }
             Error(output), Ok(python_output) -> {

--- a/test/test_data.gleam
+++ b/test/test_data.gleam
@@ -1,10 +1,11 @@
 import parse_error.{type ParseError}
+import python/python_error.{type PythonError}
 
 pub type FloatTestData {
   FloatTestData(
     input: String,
     expected_program_output: Result(Float, ParseError),
-    expected_python_output: Result(String, Nil),
+    expected_python_output: Result(String, PythonError),
   )
 }
 
@@ -13,6 +14,6 @@ pub type IntegerTestData {
     input: String,
     base: Int,
     expected_program_output: Result(Int, ParseError),
-    expected_python_output: Result(String, Nil),
+    expected_python_output: Result(String, PythonError),
   )
 }

--- a/test/to_float_parse_test.gleam
+++ b/test/to_float_parse_test.gleam
@@ -13,7 +13,7 @@ pub fn to_float_tests() {
     data.float_test_data()
       |> list.map(fn(data) {
         let input = data.input
-        let input_printable_text = input |> helpers.to_printable_text
+        let input_printable_text = input |> helpers.to_printable_text(False)
         let expected_program_output = data.expected_program_output
 
         let message = case expected_program_output {

--- a/test/to_int_parse_test.gleam
+++ b/test/to_int_parse_test.gleam
@@ -13,7 +13,7 @@ pub fn to_int_tests() {
     data.integer_test_data()
       |> list.map(fn(data) {
         let input = data.input
-        let input_printable_text = input |> helpers.to_printable_text
+        let input_printable_text = input |> helpers.to_printable_text(False)
         let expected_program_output = data.expected_program_output
         let base = data.base
 


### PR DESCRIPTION
Closes: #55 

We now return the exception error text from the parse failures in Python and compare them in our failure test by constructing the same string via the test inputs.