### PR TITLE
Fix floating point representation issue

### DIFF
--- a/src/lenient_parse/internal/math.gleam
+++ b/src/lenient_parse/internal/math.gleam
@@ -2,19 +2,17 @@ import gleam/int
 import gleam/order
 import lenient_parse/internal/base_constants.{base_10}
 
-pub fn multiply_by_power_of_10(factor: Float, base: Int, exponent: Int) {
-  do_multiply_by_power_of_10(
+pub fn expand_scientific_notation_float(factor: Float, exponent: Int) {
+  do_expand_scientific_notation_float(
     factor: factor,
-    base: base,
     exponent: exponent,
     scale_factor: 1,
     exponent_is_positive: exponent >= 0,
   )
 }
 
-fn do_multiply_by_power_of_10(
+fn do_expand_scientific_notation_float(
   factor factor: Float,
-  base base: Int,
   exponent exponent: Int,
   scale_factor scale_factor: Int,
   exponent_is_positive exponent_is_positive: Bool,
@@ -28,17 +26,15 @@ fn do_multiply_by_power_of_10(
       }
     }
     order.Gt ->
-      do_multiply_by_power_of_10(
+      do_expand_scientific_notation_float(
         factor,
-        base,
         exponent - 1,
         scale_factor * base_10,
         exponent_is_positive,
       )
     order.Lt ->
-      do_multiply_by_power_of_10(
+      do_expand_scientific_notation_float(
         factor,
-        base,
         exponent + 1,
         scale_factor * base_10,
         exponent_is_positive,

--- a/src/lenient_parse/internal/math.gleam
+++ b/src/lenient_parse/internal/math.gleam
@@ -1,0 +1,47 @@
+import gleam/int
+import gleam/order
+import lenient_parse/internal/base_constants.{base_10}
+
+pub fn multiply_by_power_of_10(factor: Float, base: Int, exponent: Int) {
+  do_multiply_by_power_of_10(
+    factor: factor,
+    base: base,
+    exponent: exponent,
+    scale_factor: 1,
+    exponent_is_positive: exponent >= 0,
+  )
+}
+
+fn do_multiply_by_power_of_10(
+  factor factor: Float,
+  base base: Int,
+  exponent exponent: Int,
+  scale_factor scale_factor: Int,
+  exponent_is_positive exponent_is_positive: Bool,
+) -> Float {
+  case int.compare(exponent, 0) {
+    order.Eq -> {
+      let scale_factor_float = scale_factor |> int.to_float
+      case exponent_is_positive {
+        True -> factor *. scale_factor_float
+        False -> factor /. scale_factor_float
+      }
+    }
+    order.Gt ->
+      do_multiply_by_power_of_10(
+        factor,
+        base,
+        exponent - 1,
+        scale_factor * base_10,
+        exponent_is_positive,
+      )
+    order.Lt ->
+      do_multiply_by_power_of_10(
+        factor,
+        base,
+        exponent + 1,
+        scale_factor * base_10,
+        exponent_is_positive,
+      )
+  }
+}

--- a/src/lenient_parse/internal/parser.gleam
+++ b/src/lenient_parse/internal/parser.gleam
@@ -7,7 +7,7 @@ import gleam/result
 import lenient_parse/internal/base_constants.{
   base_0, base_10, base_16, base_2, base_8,
 }
-import lenient_parse/internal/math.{multiply_by_power_of_10}
+import lenient_parse/internal/math.{expand_scientific_notation_float}
 import lenient_parse/internal/scale
 import lenient_parse/internal/token.{
   type Token, BasePrefix, DecimalPoint, Digit, ExponentSymbol, Sign, Underscore,
@@ -368,7 +368,7 @@ fn form_float(
     all_digits
     |> digits_to_int
     |> int.to_float
-    |> multiply_by_power_of_10(base_10, -fractional_digits_length)
+    |> expand_scientific_notation_float(-fractional_digits_length)
   use <- bool.guard(is_positive, scaled_float_value)
   scaled_float_value *. -1.0
 }

--- a/src/lenient_parse/internal/parser.gleam
+++ b/src/lenient_parse/internal/parser.gleam
@@ -2,12 +2,12 @@ import gleam/bool
 import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
-import gleam/order
 import gleam/queue.{type Queue}
 import gleam/result
 import lenient_parse/internal/base_constants.{
   base_0, base_10, base_16, base_2, base_8,
 }
+import lenient_parse/internal/math.{multiply_by_power_of_10}
 import lenient_parse/internal/scale
 import lenient_parse/internal/token.{
   type Token, BasePrefix, DecimalPoint, Digit, ExponentSymbol, Sign, Underscore,
@@ -361,20 +361,16 @@ fn form_float(
 ) -> Float {
   let #(whole_digits, fractional_digits) =
     scale.by_10(whole_digits, fractional_digits, exponent)
-
-  let whole_float = whole_digits |> digits_to_int |> int.to_float
-
   let fractional_digits_length = fractional_digits |> queue.length
-  let fractional_float =
-    fractional_digits
+  let #(all_digits, _) =
+    scale.by_10(whole_digits, fractional_digits, fractional_digits_length)
+  let scaled_float_value =
+    all_digits
     |> digits_to_int
     |> int.to_float
-    |> power(-fractional_digits_length)
-
-  case is_positive {
-    True -> whole_float +. fractional_float
-    False -> { whole_float +. fractional_float } *. -1.0
-  }
+    |> multiply_by_power_of_10(base_10, -fractional_digits_length)
+  use <- bool.guard(is_positive, scaled_float_value)
+  scaled_float_value *. -1.0
 }
 
 fn digits_to_int(digits digits: Queue(Int)) -> Int {
@@ -383,34 +379,4 @@ fn digits_to_int(digits digits: Queue(Int)) -> Int {
 
 fn digits_to_int_with_base(digits digits: Queue(Int), base base: Int) -> Int {
   digits |> queue.to_list |> list.fold(0, fn(acc, digit) { acc * base + digit })
-}
-
-fn power(base: Float, exponent: Int) {
-  do_power(
-    base: base,
-    exponent: exponent,
-    scale_factor: 1,
-    exponent_is_positive: exponent >= 0,
-  )
-}
-
-fn do_power(
-  base base: Float,
-  exponent exponent: Int,
-  scale_factor scale_factor: Int,
-  exponent_is_positive exponent_is_positive,
-) -> Float {
-  case int.compare(exponent, 0) {
-    order.Eq -> {
-      let scale_factor_float = scale_factor |> int.to_float
-      case exponent_is_positive {
-        True -> base *. scale_factor_float
-        False -> base /. scale_factor_float
-      }
-    }
-    order.Gt ->
-      do_power(base, exponent - 1, scale_factor * base_10, exponent_is_positive)
-    order.Lt ->
-      do_power(base, exponent + 1, scale_factor * base_10, exponent_is_positive)
-  }
 }

--- a/test/data/float/valid_float_data.gleam
+++ b/test/data/float/valid_float_data.gleam
@@ -7,6 +7,18 @@ const valid_simple: List(FloatTestData) = [
     expected_program_output: Ok(1.001),
     expected_python_output: Ok("1.001"),
   ),
+  // Would produce a floating point error in v1.3.1: 2.7119999999999997
+  FloatTestData(
+    input: "2.712",
+    expected_program_output: Ok(2.712),
+    expected_python_output: Ok("2.712"),
+  ),
+  // Would produce a floating point error in v1.3.1: 7.5776864147000005
+  FloatTestData(
+    input: "7.5776864147",
+    expected_program_output: Ok(7.5776864147),
+    expected_python_output: Ok("7.5776864147"),
+  ),
   FloatTestData(
     input: "1.00",
     expected_program_output: Ok(1.0),

--- a/test/math_test.gleam
+++ b/test/math_test.gleam
@@ -1,10 +1,18 @@
-import lenient_parse/internal/base_constants.{base_10}
-import lenient_parse/internal/math.{multiply_by_power_of_10}
+import lenient_parse/internal/math.{expand_scientific_notation_float}
 import startest/expect
 
-pub fn multiply_by_power_of_10_test() {
-  10.0 |> multiply_by_power_of_10(base_10, 0) |> expect.to_equal(10.0)
-  10.0 |> multiply_by_power_of_10(base_10, 1) |> expect.to_equal(100.0)
-  10.0 |> multiply_by_power_of_10(base_10, 2) |> expect.to_equal(1000.0)
-  100.0 |> multiply_by_power_of_10(base_10, -2) |> expect.to_equal(1.0)
+pub fn expand_scientific_notation_float_test() {
+  10.0 |> expand_scientific_notation_float(0) |> expect.to_equal(10.0)
+
+  10.0
+  |> expand_scientific_notation_float(1)
+  |> expect.to_equal(100.0)
+
+  10.0
+  |> expand_scientific_notation_float(2)
+  |> expect.to_equal(1000.0)
+
+  100.0
+  |> expand_scientific_notation_float(-2)
+  |> expect.to_equal(1.0)
 }

--- a/test/math_test.gleam
+++ b/test/math_test.gleam
@@ -1,0 +1,10 @@
+import lenient_parse/internal/base_constants.{base_10}
+import lenient_parse/internal/math.{multiply_by_power_of_10}
+import startest/expect
+
+pub fn multiply_by_power_of_10_test() {
+  10.0 |> multiply_by_power_of_10(base_10, 0) |> expect.to_equal(10.0)
+  10.0 |> multiply_by_power_of_10(base_10, 1) |> expect.to_equal(100.0)
+  10.0 |> multiply_by_power_of_10(base_10, 2) |> expect.to_equal(1000.0)
+  100.0 |> multiply_by_power_of_10(base_10, -2) |> expect.to_equal(1.0)
+}


### PR DESCRIPTION
```gleam
// Would produce a floating point error in v1.3.1: 2.7119999999999997
FloatTestData(
  input: "2.712",
  expected_program_output: Ok(2.712),
  expected_python_output: Ok("2.712"),
),
// Would produce a floating point error in v1.3.1: 7.5776864147000005
FloatTestData(
  input: "7.5776864147",
  expected_program_output: Ok(7.5776864147),
  expected_python_output: Ok("7.5776864147"),
),
```