### PR TITLE
Handle all whitespace characters allowed by Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ pub fn main() {
 
 `lenient_parse`'s testing is extensive. We test the tokenization step, the
 overall parse procedure, as well as various intermediate layers. We currently
-have ~500 passing tests. Regressions are **not** welcome here.
+have ~600 passing tests. Regressions are **not** welcome here.
 
 ### Backed by Python
 

--- a/script/parsable_unicode_characters.py
+++ b/script/parsable_unicode_characters.py
@@ -1,0 +1,13 @@
+parsed = []
+
+for i in range(0, 0x110000):
+    unicode = chr(i)
+    value = f"{unicode}{i}{unicode}"
+
+    try:
+        if int(value) == i:
+            parsed.append(i)
+    except Exception:
+        ...
+
+print(parsed)

--- a/src/lenient_parse/internal/parser.gleam
+++ b/src/lenient_parse/internal/parser.gleam
@@ -198,11 +198,11 @@ fn do_parse_whitespace(
   case tokens {
     [Unknown(#(start_index, _), character), ..] ->
       Error(UnknownCharacter(start_index, character))
-    [Whitespace(#(_, end_index), whitespace), ..rest] -> {
+    [Whitespace(#(_, end_index), data), ..rest] -> {
       do_parse_whitespace(
         tokens: rest,
         index: end_index,
-        acc: acc <> whitespace,
+        acc: acc <> data.character,
       )
     }
     _ -> {
@@ -306,8 +306,8 @@ fn do_parse_digits(
   case tokens {
     [Unknown(#(start_index, _), character), ..] ->
       Error(UnknownCharacter(start_index, character))
-    [Whitespace(#(start_index, _), whitespace), ..] if at_beginning ->
-      Error(UnknownCharacter(start_index, whitespace))
+    [Whitespace(#(start_index, _), data), ..] if at_beginning ->
+      Error(UnknownCharacter(start_index, data.character))
     [Underscore(#(start_index, end_index)), ..rest] -> {
       let lookahead = rest |> list.first
       let at_end = case lookahead {

--- a/src/lenient_parse/internal/token.gleam
+++ b/src/lenient_parse/internal/token.gleam
@@ -1,3 +1,4 @@
+import lenient_parse/internal/whitespace.{type WhitespaceData}
 import parse_error.{
   type ParseError, BasePrefixOnly, InvalidDecimalPosition, InvalidDigitPosition,
   InvalidExponentSymbolPosition, InvalidSignPosition, InvalidUnderscorePosition,
@@ -11,7 +12,8 @@ pub type Token {
   Underscore(#(Int, Int))
   DecimalPoint(#(Int, Int))
   ExponentSymbol(#(Int, Int), String)
-  Whitespace(#(Int, Int), String)
+  Whitespace(#(Int, Int), data: WhitespaceData)
+  // TDDO: Store value
   Unknown(#(Int, Int), String)
 }
 
@@ -27,8 +29,8 @@ pub fn to_error(token: Token, base: Int) -> ParseError {
     DecimalPoint(#(start_index, _)) -> InvalidDecimalPosition(start_index)
     ExponentSymbol(#(start_index, _), exponent_symbol) ->
       InvalidExponentSymbolPosition(start_index, exponent_symbol)
-    Whitespace(#(start_index, _), whitespace) ->
-      UnknownCharacter(start_index, whitespace)
+    Whitespace(#(start_index, _), data) ->
+      UnknownCharacter(start_index, data.printable)
     Unknown(#(start_index, _), character) ->
       UnknownCharacter(start_index, character)
   }

--- a/src/lenient_parse/internal/whitespace.gleam
+++ b/src/lenient_parse/internal/whitespace.gleam
@@ -1,0 +1,205 @@
+import gleam/dict.{type Dict}
+import gleam/list
+
+pub type WhitespaceData {
+  WhitespaceData(
+    character: String,
+    printable: String,
+    codepoint_values: List(Int),
+  )
+}
+
+pub fn character_dict() -> Dict(String, WhitespaceData) {
+  [
+    horizontal_tab,
+    line_feed,
+    vertical_tab,
+    form_feed,
+    carriage_return,
+    space,
+    next_line,
+    no_break_space,
+    ogham_space_mark,
+    en_quad,
+    em_quad,
+    en_space,
+    em_space,
+    three_per_em_space,
+    four_per_em_space,
+    six_per_em_space,
+    figure_space,
+    punctuation_space,
+    thin_space,
+    hair_space,
+    line_separator,
+    paragraph_separator,
+    narrow_no_break_space,
+    medium_mathematical_space,
+    ideographic_space,
+    windows_newline,
+  ]
+  |> list.map(fn(whitespace_data) {
+    #(whitespace_data.character, whitespace_data)
+  })
+  |> dict.from_list
+}
+
+// https://en.wikipedia.org/wiki/List_of_Unicode_characters
+
+pub const horizontal_tab = WhitespaceData(
+  character: "\u{0009}",
+  printable: "\\t",
+  codepoint_values: [0x9],
+)
+
+pub const line_feed = WhitespaceData(
+  character: "\u{000A}",
+  printable: "\\n",
+  codepoint_values: [0xA],
+)
+
+pub const vertical_tab = WhitespaceData(
+  character: "\u{000B}",
+  printable: "\\x0b",
+  codepoint_values: [0xB],
+)
+
+pub const form_feed = WhitespaceData(
+  character: "\u{000C}",
+  printable: "\\x0c",
+  codepoint_values: [0xC],
+)
+
+pub const carriage_return = WhitespaceData(
+  character: "\u{000D}",
+  printable: "\\r",
+  codepoint_values: [0xD],
+)
+
+pub const space = WhitespaceData(
+  character: "\u{0020}",
+  printable: " ",
+  codepoint_values: [0x20],
+)
+
+pub const next_line = WhitespaceData(
+  character: "\u{0085}",
+  printable: "\\x85",
+  codepoint_values: [0x85],
+)
+
+pub const no_break_space = WhitespaceData(
+  character: "\u{00A0}",
+  printable: "\\xa0",
+  codepoint_values: [0xA0],
+)
+
+pub const ogham_space_mark = WhitespaceData(
+  character: "\u{1680}",
+  printable: "\\u1680",
+  codepoint_values: [0x1680],
+)
+
+pub const en_quad = WhitespaceData(
+  character: "\u{2000}",
+  printable: "\\u2000",
+  codepoint_values: [0x2000],
+)
+
+pub const em_quad = WhitespaceData(
+  character: "\u{2001}",
+  printable: "\\u2001",
+  codepoint_values: [0x2001],
+)
+
+pub const en_space = WhitespaceData(
+  character: "\u{2002}",
+  printable: "\\u2002",
+  codepoint_values: [0x2002],
+)
+
+pub const em_space = WhitespaceData(
+  character: "\u{2003}",
+  printable: "\\u2003",
+  codepoint_values: [0x2003],
+)
+
+pub const three_per_em_space = WhitespaceData(
+  character: "\u{2004}",
+  printable: "\\u2004",
+  codepoint_values: [0x2004],
+)
+
+pub const four_per_em_space = WhitespaceData(
+  character: "\u{2005}",
+  printable: "\\u2005",
+  codepoint_values: [0x2005],
+)
+
+pub const six_per_em_space = WhitespaceData(
+  character: "\u{2006}",
+  printable: "\\u2006",
+  codepoint_values: [0x2006],
+)
+
+pub const figure_space = WhitespaceData(
+  character: "\u{2007}",
+  printable: "\\u2007",
+  codepoint_values: [0x2007],
+)
+
+pub const punctuation_space = WhitespaceData(
+  character: "\u{2008}",
+  printable: "\\u2008",
+  codepoint_values: [0x2008],
+)
+
+pub const thin_space = WhitespaceData(
+  character: "\u{2009}",
+  printable: "\\u2009",
+  codepoint_values: [0x2009],
+)
+
+pub const hair_space = WhitespaceData(
+  character: "\u{200A}",
+  printable: "\\u200a",
+  codepoint_values: [0x200A],
+)
+
+pub const line_separator = WhitespaceData(
+  character: "\u{2028}",
+  printable: "\\u2028",
+  codepoint_values: [0x2028],
+)
+
+pub const paragraph_separator = WhitespaceData(
+  character: "\u{2029}",
+  printable: "\\u2029",
+  codepoint_values: [0x2029],
+)
+
+pub const narrow_no_break_space = WhitespaceData(
+  character: "\u{202F}",
+  printable: "\\u202f",
+  codepoint_values: [0x202F],
+)
+
+pub const medium_mathematical_space = WhitespaceData(
+  character: "\u{205F}",
+  printable: "\\u205f",
+  codepoint_values: [0x205F],
+)
+
+pub const ideographic_space = WhitespaceData(
+  character: "\u{3000}",
+  printable: "\\u3000",
+  codepoint_values: [0x3000],
+)
+
+// ---- Specialty characters
+
+pub const windows_newline = WhitespaceData(
+  character: "\u{000D}\u{000A}",
+  printable: "\\r\\n",
+  codepoint_values: [0x000D, 0x000A],
+)

--- a/test/data/float/valid_float_data.gleam
+++ b/test/data/float/valid_float_data.gleam
@@ -1,271 +1,303 @@
+import gleam/dict
 import gleam/list
+import gleam/string
+import lenient_parse/internal/whitespace
 import test_data.{type FloatTestData, FloatTestData}
 
-const valid_simple: List(FloatTestData) = [
-  FloatTestData(
-    input: "1.001",
-    expected_program_output: Ok(1.001),
-    expected_python_output: Ok("1.001"),
-  ),
-  FloatTestData(
-    input: "1.00",
-    expected_program_output: Ok(1.0),
-    expected_python_output: Ok("1.0"),
-  ),
-  FloatTestData(
-    input: "1.0",
-    expected_program_output: Ok(1.0),
-    expected_python_output: Ok("1.0"),
-  ),
-  FloatTestData(
-    input: "0.1",
-    expected_program_output: Ok(0.1),
-    expected_python_output: Ok("0.1"),
-  ),
-  FloatTestData(
-    input: "+1.0",
-    expected_program_output: Ok(1.0),
-    expected_python_output: Ok("1.0"),
-  ),
-  FloatTestData(
-    input: "-1.0",
-    expected_program_output: Ok(-1.0),
-    expected_python_output: Ok("-1.0"),
-  ),
-  FloatTestData(
-    input: "+123.321",
-    expected_program_output: Ok(123.321),
-    expected_python_output: Ok("123.321"),
-  ),
-  FloatTestData(
-    input: "-123.321",
-    expected_program_output: Ok(-123.321),
-    expected_python_output: Ok("-123.321"),
-  ),
-  FloatTestData(
-    input: "1",
-    expected_program_output: Ok(1.0),
-    expected_python_output: Ok("1.0"),
-  ),
-  FloatTestData(
-    input: "1.",
-    expected_program_output: Ok(1.0),
-    expected_python_output: Ok("1.0"),
-  ),
-  FloatTestData(
-    input: ".1",
-    expected_program_output: Ok(0.1),
-    expected_python_output: Ok("0.1"),
-  ),
-  FloatTestData(
-    input: "0",
-    expected_program_output: Ok(0.0),
-    expected_python_output: Ok("0.0"),
-  ),
-  FloatTestData(
-    input: "-0",
-    expected_program_output: Ok(-0.0),
-    expected_python_output: Ok("-0.0"),
-  ),
-  FloatTestData(
-    input: "+0",
-    expected_program_output: Ok(0.0),
-    expected_python_output: Ok("0.0"),
-  ),
-  FloatTestData(
-    input: "0.0",
-    expected_program_output: Ok(0.0),
-    expected_python_output: Ok("0.0"),
-  ),
-]
+fn valid_simple() -> List(FloatTestData) {
+  [
+    FloatTestData(
+      input: "1.001",
+      expected_program_output: Ok(1.001),
+      expected_python_output: Ok("1.001"),
+    ),
+    FloatTestData(
+      input: "1.00",
+      expected_program_output: Ok(1.0),
+      expected_python_output: Ok("1.0"),
+    ),
+    FloatTestData(
+      input: "1.0",
+      expected_program_output: Ok(1.0),
+      expected_python_output: Ok("1.0"),
+    ),
+    FloatTestData(
+      input: "0.1",
+      expected_program_output: Ok(0.1),
+      expected_python_output: Ok("0.1"),
+    ),
+    FloatTestData(
+      input: "+1.0",
+      expected_program_output: Ok(1.0),
+      expected_python_output: Ok("1.0"),
+    ),
+    FloatTestData(
+      input: "-1.0",
+      expected_program_output: Ok(-1.0),
+      expected_python_output: Ok("-1.0"),
+    ),
+    FloatTestData(
+      input: "+123.321",
+      expected_program_output: Ok(123.321),
+      expected_python_output: Ok("123.321"),
+    ),
+    FloatTestData(
+      input: "-123.321",
+      expected_program_output: Ok(-123.321),
+      expected_python_output: Ok("-123.321"),
+    ),
+    FloatTestData(
+      input: "1",
+      expected_program_output: Ok(1.0),
+      expected_python_output: Ok("1.0"),
+    ),
+    FloatTestData(
+      input: "1.",
+      expected_program_output: Ok(1.0),
+      expected_python_output: Ok("1.0"),
+    ),
+    FloatTestData(
+      input: ".1",
+      expected_program_output: Ok(0.1),
+      expected_python_output: Ok("0.1"),
+    ),
+    FloatTestData(
+      input: "0",
+      expected_program_output: Ok(0.0),
+      expected_python_output: Ok("0.0"),
+    ),
+    FloatTestData(
+      input: "-0",
+      expected_program_output: Ok(-0.0),
+      expected_python_output: Ok("-0.0"),
+    ),
+    FloatTestData(
+      input: "+0",
+      expected_program_output: Ok(0.0),
+      expected_python_output: Ok("0.0"),
+    ),
+    FloatTestData(
+      input: "0.0",
+      expected_program_output: Ok(0.0),
+      expected_python_output: Ok("0.0"),
+    ),
+  ]
+}
 
-const valid_underscore: List(FloatTestData) = [
-  FloatTestData(
-    input: "1_000_000.0",
-    expected_program_output: Ok(1_000_000.0),
-    expected_python_output: Ok("1000000.0"),
-  ),
-  FloatTestData(
-    input: "1_000_000.000_1",
-    expected_program_output: Ok(1_000_000.0001),
-    expected_python_output: Ok("1000000.0001"),
-  ),
-  FloatTestData(
-    input: "1000.000_000",
-    expected_program_output: Ok(1000.0),
-    expected_python_output: Ok("1000.0"),
-  ),
-  FloatTestData(
-    input: "1_234_567.890_123",
-    expected_program_output: Ok(1_234_567.890123),
-    expected_python_output: Ok("1234567.890123"),
-  ),
-  FloatTestData(
-    input: "0.000_000_1",
-    expected_program_output: Ok(0.0000001),
-    expected_python_output: Ok("1e-07"),
-  ),
-]
+fn valid_underscore() -> List(FloatTestData) {
+  [
+    FloatTestData(
+      input: "1_000_000.0",
+      expected_program_output: Ok(1_000_000.0),
+      expected_python_output: Ok("1000000.0"),
+    ),
+    FloatTestData(
+      input: "1_000_000.000_1",
+      expected_program_output: Ok(1_000_000.0001),
+      expected_python_output: Ok("1000000.0001"),
+    ),
+    FloatTestData(
+      input: "1000.000_000",
+      expected_program_output: Ok(1000.0),
+      expected_python_output: Ok("1000.0"),
+    ),
+    FloatTestData(
+      input: "1_234_567.890_123",
+      expected_program_output: Ok(1_234_567.890123),
+      expected_python_output: Ok("1234567.890123"),
+    ),
+    FloatTestData(
+      input: "0.000_000_1",
+      expected_program_output: Ok(0.0000001),
+      expected_python_output: Ok("1e-07"),
+    ),
+  ]
+}
 
-const valid_whitespace: List(FloatTestData) = [
-  FloatTestData(
-    input: " 1 ",
-    expected_program_output: Ok(1.0),
-    expected_python_output: Ok("1.0"),
-  ),
-  FloatTestData(
-    input: " 1.0 ",
-    expected_program_output: Ok(1.0),
-    expected_python_output: Ok("1.0"),
-  ),
-  FloatTestData(
-    input: " 1000 ",
-    expected_program_output: Ok(1000.0),
-    expected_python_output: Ok("1000.0"),
-  ),
-  FloatTestData(
-    input: "\t3.14\n",
-    expected_program_output: Ok(3.14),
-    expected_python_output: Ok("3.14"),
-  ),
-  FloatTestData(
-    input: "  -0.5  ",
-    expected_program_output: Ok(-0.5),
-    expected_python_output: Ok("-0.5"),
-  ),
-]
+fn valid_whitespace() -> List(FloatTestData) {
+  let all_whitespace_characters_string =
+    whitespace.character_dict() |> dict.keys |> string.join("")
 
-const valid_exponent_symbol_position: List(FloatTestData) = [
-  FloatTestData(
-    input: "4e3",
-    expected_program_output: Ok(4000.0),
-    expected_python_output: Ok("4000.0"),
-  ),
-  FloatTestData(
-    input: "4e-3",
-    expected_program_output: Ok(0.004),
-    expected_python_output: Ok("0.004"),
-  ),
-  FloatTestData(
-    input: "4.0e3",
-    expected_program_output: Ok(4000.0),
-    expected_python_output: Ok("4000.0"),
-  ),
-  FloatTestData(
-    input: "4.0e-3",
-    expected_program_output: Ok(0.004),
-    expected_python_output: Ok("0.004"),
-  ),
-  FloatTestData(
-    input: "4E3",
-    expected_program_output: Ok(4000.0),
-    expected_python_output: Ok("4000.0"),
-  ),
-  FloatTestData(
-    input: "4E-3",
-    expected_program_output: Ok(0.004),
-    expected_python_output: Ok("0.004"),
-  ),
-  FloatTestData(
-    input: "4.0E3",
-    expected_program_output: Ok(4000.0),
-    expected_python_output: Ok("4000.0"),
-  ),
-  FloatTestData(
-    input: "4.0E-3",
-    expected_program_output: Ok(0.004),
-    expected_python_output: Ok("0.004"),
-  ),
-  FloatTestData(
-    input: ".3e3",
-    expected_program_output: Ok(300.0),
-    expected_python_output: Ok("300.0"),
-  ),
-  FloatTestData(
-    input: ".3e-3",
-    expected_program_output: Ok(0.0003),
-    expected_python_output: Ok("0.0003"),
-  ),
-  FloatTestData(
-    input: "3.e3",
-    expected_program_output: Ok(3000.0),
-    expected_python_output: Ok("3000.0"),
-  ),
-  FloatTestData(
-    input: "3.e-3",
-    expected_program_output: Ok(0.003),
-    expected_python_output: Ok("0.003"),
-  ),
-  FloatTestData(
-    input: "1e0",
-    expected_program_output: Ok(1.0),
-    expected_python_output: Ok("1.0"),
-  ),
-  FloatTestData(
-    input: "1e+3",
-    expected_program_output: Ok(1000.0),
-    expected_python_output: Ok("1000.0"),
-  ),
-  FloatTestData(
-    input: "1E+3",
-    expected_program_output: Ok(1000.0),
-    expected_python_output: Ok("1000.0"),
-  ),
-]
+  [
+    FloatTestData(
+      input: " 1 ",
+      expected_program_output: Ok(1.0),
+      expected_python_output: Ok("1.0"),
+    ),
+    FloatTestData(
+      input: " 1.0 ",
+      expected_program_output: Ok(1.0),
+      expected_python_output: Ok("1.0"),
+    ),
+    FloatTestData(
+      input: " 1000 ",
+      expected_program_output: Ok(1000.0),
+      expected_python_output: Ok("1000.0"),
+    ),
+    FloatTestData(
+      input: "\t3.14\n",
+      expected_program_output: Ok(3.14),
+      expected_python_output: Ok("3.14"),
+    ),
+    FloatTestData(
+      input: "  -0.5  ",
+      expected_program_output: Ok(-0.5),
+      expected_python_output: Ok("-0.5"),
+    ),
+    FloatTestData(
+      input: whitespace.em_space.character
+        <> "-0.6"
+        <> whitespace.em_space.character,
+      expected_program_output: Ok(-0.6),
+      expected_python_output: Ok("-0.6"),
+    ),
+    FloatTestData(
+      input: all_whitespace_characters_string
+        <> "666.0"
+        <> all_whitespace_characters_string,
+      expected_program_output: Ok(666.0),
+      expected_python_output: Ok("666.0"),
+    ),
+  ]
+}
 
-const precision: List(FloatTestData) = [
-  // Would produce a floating point error in v1.3.1: 2.7119999999999997
-  FloatTestData(
-    input: "2.712",
-    expected_program_output: Ok(2.712),
-    expected_python_output: Ok("2.712"),
-  ),
-  // Would produce a floating point error in v1.3.1: 7.5776864147000005
-  FloatTestData(
-    input: "7.5776864147",
-    expected_program_output: Ok(7.5776864147),
-    expected_python_output: Ok("7.5776864147"),
-  ),
-  // Would produce a floating point error in v1.3.2: 8556272791.328557
-  FloatTestData(
-    input: "8556272791.3285562727",
-    expected_program_output: Ok(8_556_272_791.328556),
-    // Python rounds this value
-    expected_python_output: Ok("8556272791.328556"),
-  ),
-]
+fn valid_exponent_symbol_position() -> List(FloatTestData) {
+  [
+    FloatTestData(
+      input: "4e3",
+      expected_program_output: Ok(4000.0),
+      expected_python_output: Ok("4000.0"),
+    ),
+    FloatTestData(
+      input: "4e-3",
+      expected_program_output: Ok(0.004),
+      expected_python_output: Ok("0.004"),
+    ),
+    FloatTestData(
+      input: "4.0e3",
+      expected_program_output: Ok(4000.0),
+      expected_python_output: Ok("4000.0"),
+    ),
+    FloatTestData(
+      input: "4.0e-3",
+      expected_program_output: Ok(0.004),
+      expected_python_output: Ok("0.004"),
+    ),
+    FloatTestData(
+      input: "4E3",
+      expected_program_output: Ok(4000.0),
+      expected_python_output: Ok("4000.0"),
+    ),
+    FloatTestData(
+      input: "4E-3",
+      expected_program_output: Ok(0.004),
+      expected_python_output: Ok("0.004"),
+    ),
+    FloatTestData(
+      input: "4.0E3",
+      expected_program_output: Ok(4000.0),
+      expected_python_output: Ok("4000.0"),
+    ),
+    FloatTestData(
+      input: "4.0E-3",
+      expected_program_output: Ok(0.004),
+      expected_python_output: Ok("0.004"),
+    ),
+    FloatTestData(
+      input: ".3e3",
+      expected_program_output: Ok(300.0),
+      expected_python_output: Ok("300.0"),
+    ),
+    FloatTestData(
+      input: ".3e-3",
+      expected_program_output: Ok(0.0003),
+      expected_python_output: Ok("0.0003"),
+    ),
+    FloatTestData(
+      input: "3.e3",
+      expected_program_output: Ok(3000.0),
+      expected_python_output: Ok("3000.0"),
+    ),
+    FloatTestData(
+      input: "3.e-3",
+      expected_program_output: Ok(0.003),
+      expected_python_output: Ok("0.003"),
+    ),
+    FloatTestData(
+      input: "1e0",
+      expected_program_output: Ok(1.0),
+      expected_python_output: Ok("1.0"),
+    ),
+    FloatTestData(
+      input: "1e+3",
+      expected_program_output: Ok(1000.0),
+      expected_python_output: Ok("1000.0"),
+    ),
+    FloatTestData(
+      input: "1E+3",
+      expected_program_output: Ok(1000.0),
+      expected_python_output: Ok("1000.0"),
+    ),
+  ]
+}
 
-const valid_mixed: List(FloatTestData) = [
-  FloatTestData(
-    input: "   -30.01e-2   ",
-    expected_program_output: Ok(-0.3001),
-    expected_python_output: Ok("-0.3001"),
-  ),
-  FloatTestData(
-    input: "+1_234.567_8e-2",
-    expected_program_output: Ok(12.345678),
-    expected_python_output: Ok("12.345678"),
-  ),
-  FloatTestData(
-    input: "-1_234.567_8e-2",
-    expected_program_output: Ok(-12.345678),
-    expected_python_output: Ok("-12.345678"),
-  ),
-  FloatTestData(
-    input: " -0.000_1E+3 ",
-    expected_program_output: Ok(-0.1),
-    expected_python_output: Ok("-0.1"),
-  ),
-]
+fn precision() -> List(FloatTestData) {
+  [
+    // Would produce a floating point error in v1.3.1: 2.7119999999999997
+    FloatTestData(
+      input: "2.712",
+      expected_program_output: Ok(2.712),
+      expected_python_output: Ok("2.712"),
+    ),
+    // Would produce a floating point error in v1.3.1: 7.5776864147000005
+    FloatTestData(
+      input: "7.5776864147",
+      expected_program_output: Ok(7.5776864147),
+      expected_python_output: Ok("7.5776864147"),
+    ),
+    // Would produce a floating point error in v1.3.2: 8556272791.328557
+    FloatTestData(
+      input: "8556272791.3285562727",
+      expected_program_output: Ok(8_556_272_791.328556),
+      // Python rounds this value
+      expected_python_output: Ok("8556272791.328556"),
+    ),
+  ]
+}
+
+fn valid_mixed() -> List(FloatTestData) {
+  [
+    FloatTestData(
+      input: "   -30.01e-2   ",
+      expected_program_output: Ok(-0.3001),
+      expected_python_output: Ok("-0.3001"),
+    ),
+    FloatTestData(
+      input: "+1_234.567_8e-2",
+      expected_program_output: Ok(12.345678),
+      expected_python_output: Ok("12.345678"),
+    ),
+    FloatTestData(
+      input: "-1_234.567_8e-2",
+      expected_program_output: Ok(-12.345678),
+      expected_python_output: Ok("-12.345678"),
+    ),
+    FloatTestData(
+      input: " -0.000_1E+3 ",
+      expected_program_output: Ok(-0.1),
+      expected_python_output: Ok("-0.1"),
+    ),
+  ]
+}
 
 pub fn data() -> List(FloatTestData) {
   [
-    valid_simple,
-    valid_underscore,
-    valid_whitespace,
-    valid_exponent_symbol_position,
-    precision,
-    valid_mixed,
+    valid_simple(),
+    valid_underscore(),
+    valid_whitespace(),
+    valid_exponent_symbol_position(),
+    precision(),
+    valid_mixed(),
   ]
   |> list.flatten
 }

--- a/test/data/integer/invalid_integer_data.gleam
+++ b/test/data/integer/invalid_integer_data.gleam
@@ -1,7 +1,10 @@
+import gleam/dict
 import gleam/int
 import gleam/list
+import gleam/string
 import helpers
 import lenient_parse/internal/base_constants.{base_0, base_10, base_2, base_8}
+import lenient_parse/internal/whitespace
 import parse_error.{
   type ParseError, BasePrefixOnly, EmptyString, InvalidBaseValue,
   InvalidDigitPosition, InvalidSignPosition, InvalidUnderscorePosition,
@@ -31,7 +34,7 @@ fn integer_test_data(
   expected_program_output expected_program_output: Result(Int, ParseError),
   python_error_function python_error_function: fn(String, Int) -> PythonError,
 ) -> IntegerTestData {
-  let printable_text = input |> helpers.to_printable_text(True)
+  let printable_text = input |> helpers.to_printable_text
 
   IntegerTestData(
     input: input,
@@ -42,6 +45,9 @@ fn integer_test_data(
 }
 
 fn invalid_empty_or_whitespace() -> List(IntegerTestData) {
+  let all_whitespace_characters_string =
+    whitespace.character_dict() |> dict.keys |> string.join("")
+
   [
     integer_test_data(
       input: "",
@@ -51,6 +57,12 @@ fn invalid_empty_or_whitespace() -> List(IntegerTestData) {
     ),
     integer_test_data(
       input: " ",
+      base: base_10,
+      expected_program_output: Error(WhitespaceOnlyString),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "   ",
       base: base_10,
       expected_program_output: Error(WhitespaceOnlyString),
       python_error_function: invalid_literal_for_int_error,
@@ -92,7 +104,7 @@ fn invalid_empty_or_whitespace() -> List(IntegerTestData) {
       python_error_function: invalid_literal_for_int_error,
     ),
     integer_test_data(
-      input: "   ",
+      input: all_whitespace_characters_string,
       base: base_10,
       expected_program_output: Error(WhitespaceOnlyString),
       python_error_function: invalid_literal_for_int_error,
@@ -177,6 +189,15 @@ fn unknown_characters() -> List(IntegerTestData) {
       input: "+ 1",
       base: base_10,
       expected_program_output: Error(UnknownCharacter(1, " ")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "+" <> whitespace.hair_space.character <> "1",
+      base: base_10,
+      expected_program_output: Error(UnknownCharacter(
+        1,
+        whitespace.hair_space.character,
+      )),
       python_error_function: invalid_literal_for_int_error,
     ),
     integer_test_data(
@@ -337,6 +358,163 @@ fn invalid_digit_position() -> List(IntegerTestData) {
       input: "123 456",
       base: base_10,
       expected_program_output: Error(InvalidDigitPosition(4, "4")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    // Unicode cases
+    integer_test_data(
+      input: "7" <> whitespace.horizontal_tab.character <> "9",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "9")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "7" <> whitespace.line_feed.character <> "8",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "8")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "2" <> whitespace.vertical_tab.character <> "3",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "3")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "3" <> whitespace.form_feed.character <> "4",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "4")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "5" <> whitespace.carriage_return.character <> "6",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "6")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "6" <> whitespace.space.character <> "7",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "7")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "8" <> whitespace.next_line.character <> "9",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "9")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "9" <> whitespace.no_break_space.character <> "0",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "0")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "0" <> whitespace.ogham_space_mark.character <> "1",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "1")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1" <> whitespace.en_quad.character <> "2",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "2")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "2" <> whitespace.em_quad.character <> "3",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "3")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "3" <> whitespace.en_space.character <> "4",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "4")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "5" <> whitespace.em_space.character <> "6",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "6")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "6" <> whitespace.three_per_em_space.character <> "7",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "7")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "7" <> whitespace.four_per_em_space.character <> "8",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "8")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "8" <> whitespace.six_per_em_space.character <> "9",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "9")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "9" <> whitespace.figure_space.character <> "0",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "0")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "0" <> whitespace.punctuation_space.character <> "1",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "1")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1" <> whitespace.thin_space.character <> "2",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "2")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "2" <> whitespace.hair_space.character <> "3",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "3")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "3" <> whitespace.line_separator.character <> "4",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "4")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "5" <> whitespace.paragraph_separator.character <> "6",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "6")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "6" <> whitespace.narrow_no_break_space.character <> "7",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "7")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "7" <> whitespace.medium_mathematical_space.character <> "8",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "8")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "8" <> whitespace.ideographic_space.character <> "9",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "9")),
+      python_error_function: invalid_literal_for_int_error,
+    ),
+    integer_test_data(
+      input: "1" <> whitespace.windows_newline.character <> "0",
+      base: base_10,
+      expected_program_output: Error(InvalidDigitPosition(2, "0")),
       python_error_function: invalid_literal_for_int_error,
     ),
   ]

--- a/test/data/integer/valid_integer_data.gleam
+++ b/test/data/integer/valid_integer_data.gleam
@@ -1,348 +1,583 @@
+import gleam/dict
 import gleam/list
+import gleam/string
 import lenient_parse/internal/base_constants.{
   base_0, base_10, base_16, base_2, base_8,
 }
+import lenient_parse/internal/whitespace
 import test_data.{type IntegerTestData, IntegerTestData}
 
-const valid_simple: List(IntegerTestData) = [
-  IntegerTestData(
-    input: "1",
-    base: base_10,
-    expected_program_output: Ok(1),
-    expected_python_output: Ok("1"),
-  ),
-  IntegerTestData(
-    input: "+123",
-    base: base_10,
-    expected_program_output: Ok(123),
-    expected_python_output: Ok("123"),
-  ),
-  IntegerTestData(
-    input: "-123",
-    base: base_10,
-    expected_program_output: Ok(-123),
-    expected_python_output: Ok("-123"),
-  ),
-  IntegerTestData(
-    input: "0123",
-    base: base_10,
-    expected_program_output: Ok(123),
-    expected_python_output: Ok("123"),
-  ),
-  IntegerTestData(
-    input: "9876",
-    base: base_10,
-    expected_program_output: Ok(9876),
-    expected_python_output: Ok("9876"),
-  ),
-  IntegerTestData(
-    input: "-10",
-    base: base_10,
-    expected_program_output: Ok(-10),
-    expected_python_output: Ok("-10"),
-  ),
-  IntegerTestData(
-    input: "01_32",
-    base: 4,
-    expected_program_output: Ok(30),
-    expected_python_output: Ok("30"),
-  ),
-  IntegerTestData(
-    input: "+0",
-    base: base_10,
-    expected_program_output: Ok(0),
-    expected_python_output: Ok("0"),
-  ),
-  IntegerTestData(
-    input: "42",
-    base: base_10,
-    expected_program_output: Ok(42),
-    expected_python_output: Ok("42"),
-  ),
-  IntegerTestData(
-    input: "-987654",
-    base: base_10,
-    expected_program_output: Ok(-987_654),
-    expected_python_output: Ok("-987654"),
-  ),
-]
+fn valid_simple() -> List(IntegerTestData) {
+  [
+    IntegerTestData(
+      input: "1",
+      base: base_10,
+      expected_program_output: Ok(1),
+      expected_python_output: Ok("1"),
+    ),
+    IntegerTestData(
+      input: "+123",
+      base: base_10,
+      expected_program_output: Ok(123),
+      expected_python_output: Ok("123"),
+    ),
+    IntegerTestData(
+      input: "-123",
+      base: base_10,
+      expected_program_output: Ok(-123),
+      expected_python_output: Ok("-123"),
+    ),
+    IntegerTestData(
+      input: "0123",
+      base: base_10,
+      expected_program_output: Ok(123),
+      expected_python_output: Ok("123"),
+    ),
+    IntegerTestData(
+      input: "9876",
+      base: base_10,
+      expected_program_output: Ok(9876),
+      expected_python_output: Ok("9876"),
+    ),
+    IntegerTestData(
+      input: "-10",
+      base: base_10,
+      expected_program_output: Ok(-10),
+      expected_python_output: Ok("-10"),
+    ),
+    IntegerTestData(
+      input: "01_32",
+      base: 4,
+      expected_program_output: Ok(30),
+      expected_python_output: Ok("30"),
+    ),
+    IntegerTestData(
+      input: "+0",
+      base: base_10,
+      expected_program_output: Ok(0),
+      expected_python_output: Ok("0"),
+    ),
+    IntegerTestData(
+      input: "42",
+      base: base_10,
+      expected_program_output: Ok(42),
+      expected_python_output: Ok("42"),
+    ),
+    IntegerTestData(
+      input: "-987654",
+      base: base_10,
+      expected_program_output: Ok(-987_654),
+      expected_python_output: Ok("-987654"),
+    ),
+  ]
+}
 
-const valid_simple_base_2: List(IntegerTestData) = [
-  IntegerTestData(
-    input: "0",
-    base: base_2,
-    expected_program_output: Ok(0),
-    expected_python_output: Ok("0"),
-  ),
-  IntegerTestData(
-    input: "101",
-    base: base_2,
-    expected_program_output: Ok(0b101),
-    expected_python_output: Ok("5"),
-  ),
-  IntegerTestData(
-    input: "11111",
-    base: base_2,
-    expected_program_output: Ok(0b11111),
-    expected_python_output: Ok("31"),
-  ),
-  IntegerTestData(
-    input: "-11111",
-    base: base_2,
-    expected_program_output: Ok(-31),
-    expected_python_output: Ok("-31"),
-  ),
-  IntegerTestData(
-    input: "  1_1_1  ",
-    base: base_2,
-    expected_program_output: Ok(0b111),
-    expected_python_output: Ok("7"),
-  ),
-]
+fn valid_simple_base_2() -> List(IntegerTestData) {
+  [
+    IntegerTestData(
+      input: "0",
+      base: base_2,
+      expected_program_output: Ok(0),
+      expected_python_output: Ok("0"),
+    ),
+    IntegerTestData(
+      input: "101",
+      base: base_2,
+      expected_program_output: Ok(0b101),
+      expected_python_output: Ok("5"),
+    ),
+    IntegerTestData(
+      input: "11111",
+      base: base_2,
+      expected_program_output: Ok(0b11111),
+      expected_python_output: Ok("31"),
+    ),
+    IntegerTestData(
+      input: "-11111",
+      base: base_2,
+      expected_program_output: Ok(-31),
+      expected_python_output: Ok("-31"),
+    ),
+    IntegerTestData(
+      input: "  1_1_1  ",
+      base: base_2,
+      expected_program_output: Ok(0b111),
+      expected_python_output: Ok("7"),
+    ),
+  ]
+}
 
-const valid_simple_base_8: List(IntegerTestData) = [
-  IntegerTestData(
-    input: "0",
-    base: base_8,
-    expected_program_output: Ok(0),
-    expected_python_output: Ok("0"),
-  ),
-  IntegerTestData(
-    input: "77",
-    base: base_8,
-    expected_program_output: Ok(0o77),
-    expected_python_output: Ok("63"),
-  ),
-]
+fn valid_simple_base_8() -> List(IntegerTestData) {
+  [
+    IntegerTestData(
+      input: "0",
+      base: base_8,
+      expected_program_output: Ok(0),
+      expected_python_output: Ok("0"),
+    ),
+    IntegerTestData(
+      input: "77",
+      base: base_8,
+      expected_program_output: Ok(0o77),
+      expected_python_output: Ok("63"),
+    ),
+  ]
+}
 
-const valid_simple_base_16: List(IntegerTestData) = [
-  IntegerTestData(
-    input: "DEAD_BEEF",
-    base: base_16,
-    expected_program_output: Ok(0xDEADBEEF),
-    expected_python_output: Ok("3735928559"),
-  ),
-  IntegerTestData(
-    input: "ABCDEF",
-    base: base_16,
-    expected_program_output: Ok(0xABCDEF),
-    expected_python_output: Ok("11259375"),
-  ),
-]
+fn valid_simple_base_16() -> List(IntegerTestData) {
+  [
+    IntegerTestData(
+      input: "DEAD_BEEF",
+      base: base_16,
+      expected_program_output: Ok(0xDEADBEEF),
+      expected_python_output: Ok("3735928559"),
+    ),
+    IntegerTestData(
+      input: "ABCDEF",
+      base: base_16,
+      expected_program_output: Ok(0xABCDEF),
+      expected_python_output: Ok("11259375"),
+    ),
+  ]
+}
 
-const valid_simple_base_prefix: List(IntegerTestData) = [
-  // Base 0, has lowercase binary prefix
-  IntegerTestData(
-    input: "0b10",
-    base: base_0,
-    expected_program_output: Ok(0b10),
-    expected_python_output: Ok("2"),
-  ),
-  // Base 0, has uppercase binary prefix
-  IntegerTestData(
-    input: "0B10",
-    base: base_0,
-    expected_program_output: Ok(0b10),
-    expected_python_output: Ok("2"),
-  ),
-  // Base 0, has lowercase octal prefix
-  IntegerTestData(
-    input: "0o01234",
-    base: base_0,
-    expected_program_output: Ok(0o01234),
-    expected_python_output: Ok("668"),
-  ),
-  // Base 0, has uppercase octal prefix
-  IntegerTestData(
-    input: "0O01234",
-    base: base_0,
-    expected_program_output: Ok(0o01234),
-    expected_python_output: Ok("668"),
-  ),
-  // Base 0, has lowercase hexadecimal prefix
-  IntegerTestData(
-    input: "0xDEADBEEF",
-    base: base_0,
-    expected_program_output: Ok(0xDEADBEEF),
-    expected_python_output: Ok("3735928559"),
-  ),
-  // Base 0, has uppercase hexadecimal prefix
-  IntegerTestData(
-    input: "0XDEADBEEF",
-    base: base_0,
-    expected_program_output: Ok(0xDEADBEEF),
-    expected_python_output: Ok("3735928559"),
-  ),
-  // Base 0, has no prefix, default to decimal
-  IntegerTestData(
-    input: " \n6_666",
-    base: base_0,
-    expected_program_output: Ok(6666),
-    expected_python_output: Ok("6666"),
-  ),
-  // Base 0, has lowercase hexadecimal prefix, and an underscore between the prefix and the number
-  IntegerTestData(
-    input: "0x_DEAD_BEEF",
-    base: base_0,
-    expected_program_output: Ok(0xDEADBEEF),
-    expected_python_output: Ok("3735928559"),
-  ),
-  // Base 0, has uppercase hexadecimal prefix, and an underscore between the prefix and the number
-  IntegerTestData(
-    input: "0X_DEAD_BEEF",
-    base: base_0,
-    expected_program_output: Ok(0xDEADBEEF),
-    expected_python_output: Ok("3735928559"),
-  ),
-  // Base 2 and has lowercase binary prefix
-  IntegerTestData(
-    input: "0b1001",
-    base: base_2,
-    expected_program_output: Ok(0b1001),
-    expected_python_output: Ok("9"),
-  ),
-  // Base 2 and has uppercase binary prefix
-  IntegerTestData(
-    input: "0B1001",
-    base: base_2,
-    expected_program_output: Ok(0b1001),
-    expected_python_output: Ok("9"),
-  ),
-  // Base 8 and has lowercase octal prefix
-  IntegerTestData(
-    input: "0o777",
-    base: base_8,
-    expected_program_output: Ok(0o777),
-    expected_python_output: Ok("511"),
-  ),
-  // Base 8 and has uppercase octal prefix
-  IntegerTestData(
-    input: "0O777",
-    base: base_8,
-    expected_program_output: Ok(0o777),
-    expected_python_output: Ok("511"),
-  ),
-  // Base 16 and has lowercase hexadecimal prefix
-  IntegerTestData(
-    input: "0xDEAD_BEEF",
-    base: base_16,
-    expected_program_output: Ok(0xDEAD_BEEF),
-    expected_python_output: Ok("3735928559"),
-  ),
-  // Base 16 and has uppercase hexadecimal prefix
-  IntegerTestData(
-    input: "0XDEAD_BEEF",
-    base: base_16,
-    expected_program_output: Ok(0xDEAD_BEEF),
-    expected_python_output: Ok("3735928559"),
-  ),
-]
+fn valid_simple_base_prefix() -> List(IntegerTestData) {
+  [
+    // Base 0, has lowercase binary prefix
+    IntegerTestData(
+      input: "0b10",
+      base: base_0,
+      expected_program_output: Ok(0b10),
+      expected_python_output: Ok("2"),
+    ),
+    // Base 0, has uppercase binary prefix
+    IntegerTestData(
+      input: "0B10",
+      base: base_0,
+      expected_program_output: Ok(0b10),
+      expected_python_output: Ok("2"),
+    ),
+    // Base 0, has lowercase octal prefix
+    IntegerTestData(
+      input: "0o01234",
+      base: base_0,
+      expected_program_output: Ok(0o01234),
+      expected_python_output: Ok("668"),
+    ),
+    // Base 0, has uppercase octal prefix
+    IntegerTestData(
+      input: "0O01234",
+      base: base_0,
+      expected_program_output: Ok(0o01234),
+      expected_python_output: Ok("668"),
+    ),
+    // Base 0, has lowercase hexadecimal prefix
+    IntegerTestData(
+      input: "0xDEADBEEF",
+      base: base_0,
+      expected_program_output: Ok(0xDEADBEEF),
+      expected_python_output: Ok("3735928559"),
+    ),
+    // Base 0, has uppercase hexadecimal prefix
+    IntegerTestData(
+      input: "0XDEADBEEF",
+      base: base_0,
+      expected_program_output: Ok(0xDEADBEEF),
+      expected_python_output: Ok("3735928559"),
+    ),
+    // Base 0, has no prefix, default to decimal
+    IntegerTestData(
+      input: " \n6_666",
+      base: base_0,
+      expected_program_output: Ok(6666),
+      expected_python_output: Ok("6666"),
+    ),
+    // Base 0, has lowercase hexadecimal prefix, and an underscore between the prefix and the number
+    IntegerTestData(
+      input: "0x_DEAD_BEEF",
+      base: base_0,
+      expected_program_output: Ok(0xDEADBEEF),
+      expected_python_output: Ok("3735928559"),
+    ),
+    // Base 0, has uppercase hexadecimal prefix, and an underscore between the prefix and the number
+    IntegerTestData(
+      input: "0X_DEAD_BEEF",
+      base: base_0,
+      expected_program_output: Ok(0xDEADBEEF),
+      expected_python_output: Ok("3735928559"),
+    ),
+    // Base 2 and has lowercase binary prefix
+    IntegerTestData(
+      input: "0b1001",
+      base: base_2,
+      expected_program_output: Ok(0b1001),
+      expected_python_output: Ok("9"),
+    ),
+    // Base 2 and has uppercase binary prefix
+    IntegerTestData(
+      input: "0B1001",
+      base: base_2,
+      expected_program_output: Ok(0b1001),
+      expected_python_output: Ok("9"),
+    ),
+    // Base 8 and has lowercase octal prefix
+    IntegerTestData(
+      input: "0o777",
+      base: base_8,
+      expected_program_output: Ok(0o777),
+      expected_python_output: Ok("511"),
+    ),
+    // Base 8 and has uppercase octal prefix
+    IntegerTestData(
+      input: "0O777",
+      base: base_8,
+      expected_program_output: Ok(0o777),
+      expected_python_output: Ok("511"),
+    ),
+    // Base 16 and has lowercase hexadecimal prefix
+    IntegerTestData(
+      input: "0xDEAD_BEEF",
+      base: base_16,
+      expected_program_output: Ok(0xDEAD_BEEF),
+      expected_python_output: Ok("3735928559"),
+    ),
+    // Base 16 and has uppercase hexadecimal prefix
+    IntegerTestData(
+      input: "0XDEAD_BEEF",
+      base: base_16,
+      expected_program_output: Ok(0xDEAD_BEEF),
+      expected_python_output: Ok("3735928559"),
+    ),
+  ]
+}
 
-const valid_underscore: List(IntegerTestData) = [
-  IntegerTestData(
-    input: "1_000",
-    base: base_10,
-    expected_program_output: Ok(1000),
-    expected_python_output: Ok("1000"),
-  ),
-  IntegerTestData(
-    input: "1_000_000",
-    base: base_10,
-    expected_program_output: Ok(1_000_000),
-    expected_python_output: Ok("1000000"),
-  ),
-  IntegerTestData(
-    input: "1_234_567_890",
-    base: base_10,
-    expected_program_output: Ok(1_234_567_890),
-    expected_python_output: Ok("1234567890"),
-  ),
-  IntegerTestData(
-    input: "-1_000_000",
-    base: base_10,
-    expected_program_output: Ok(-1_000_000),
-    expected_python_output: Ok("-1000000"),
-  ),
-  IntegerTestData(
-    input: "+1_234_567",
-    base: base_10,
-    expected_program_output: Ok(1_234_567),
-    expected_python_output: Ok("1234567"),
-  ),
-  IntegerTestData(
-    input: "9_876_543_210",
-    base: base_10,
-    expected_program_output: Ok(9_876_543_210),
-    expected_python_output: Ok("9876543210"),
-  ),
-]
+fn valid_underscore() -> List(IntegerTestData) {
+  [
+    IntegerTestData(
+      input: "1_000",
+      base: base_10,
+      expected_program_output: Ok(1000),
+      expected_python_output: Ok("1000"),
+    ),
+    IntegerTestData(
+      input: "1_000_000",
+      base: base_10,
+      expected_program_output: Ok(1_000_000),
+      expected_python_output: Ok("1000000"),
+    ),
+    IntegerTestData(
+      input: "1_234_567_890",
+      base: base_10,
+      expected_program_output: Ok(1_234_567_890),
+      expected_python_output: Ok("1234567890"),
+    ),
+    IntegerTestData(
+      input: "-1_000_000",
+      base: base_10,
+      expected_program_output: Ok(-1_000_000),
+      expected_python_output: Ok("-1000000"),
+    ),
+    IntegerTestData(
+      input: "+1_234_567",
+      base: base_10,
+      expected_program_output: Ok(1_234_567),
+      expected_python_output: Ok("1234567"),
+    ),
+    IntegerTestData(
+      input: "9_876_543_210",
+      base: base_10,
+      expected_program_output: Ok(9_876_543_210),
+      expected_python_output: Ok("9876543210"),
+    ),
+  ]
+}
 
-const valid_whitespace: List(IntegerTestData) = [
-  IntegerTestData(
-    input: " +123 ",
-    base: base_10,
-    expected_program_output: Ok(123),
-    expected_python_output: Ok("123"),
-  ),
-  IntegerTestData(
-    input: " -123 ",
-    base: base_10,
-    expected_program_output: Ok(-123),
-    expected_python_output: Ok("-123"),
-  ),
-  IntegerTestData(
-    input: " 0123",
-    base: base_10,
-    expected_program_output: Ok(123),
-    expected_python_output: Ok("123"),
-  ),
-  IntegerTestData(
-    input: " 1 ",
-    base: base_10,
-    expected_program_output: Ok(1),
-    expected_python_output: Ok("1"),
-  ),
-  IntegerTestData(
-    input: "42 ",
-    base: base_10,
-    expected_program_output: Ok(42),
-    expected_python_output: Ok("42"),
-  ),
-  IntegerTestData(
-    input: " +0 ",
-    base: base_10,
-    expected_program_output: Ok(0),
-    expected_python_output: Ok("0"),
-  ),
-  IntegerTestData(
-    input: "  -987  ",
-    base: base_10,
-    expected_program_output: Ok(-987),
-    expected_python_output: Ok("-987"),
-  ),
-  IntegerTestData(
-    input: "\t123\t",
-    base: base_10,
-    expected_program_output: Ok(123),
-    expected_python_output: Ok("123"),
-  ),
-  IntegerTestData(
-    input: "\n456\n",
-    base: base_10,
-    expected_program_output: Ok(456),
-    expected_python_output: Ok("456"),
-  ),
-]
+fn valid_whitespace() -> List(IntegerTestData) {
+  let all_whitespace_characters_string =
+    whitespace.character_dict() |> dict.keys |> string.join("")
+
+  [
+    IntegerTestData(
+      input: " +123 ",
+      base: base_10,
+      expected_program_output: Ok(123),
+      expected_python_output: Ok("123"),
+    ),
+    IntegerTestData(
+      input: " -123 ",
+      base: base_10,
+      expected_program_output: Ok(-123),
+      expected_python_output: Ok("-123"),
+    ),
+    IntegerTestData(
+      input: " 0123",
+      base: base_10,
+      expected_program_output: Ok(123),
+      expected_python_output: Ok("123"),
+    ),
+    IntegerTestData(
+      input: " 1 ",
+      base: base_10,
+      expected_program_output: Ok(1),
+      expected_python_output: Ok("1"),
+    ),
+    IntegerTestData(
+      input: "42 ",
+      base: base_10,
+      expected_program_output: Ok(42),
+      expected_python_output: Ok("42"),
+    ),
+    IntegerTestData(
+      input: " +0 ",
+      base: base_10,
+      expected_program_output: Ok(0),
+      expected_python_output: Ok("0"),
+    ),
+    IntegerTestData(
+      input: "  -987  ",
+      base: base_10,
+      expected_program_output: Ok(-987),
+      expected_python_output: Ok("-987"),
+    ),
+    IntegerTestData(
+      input: "\t123\t",
+      base: base_10,
+      expected_program_output: Ok(123),
+      expected_python_output: Ok("123"),
+    ),
+    IntegerTestData(
+      input: "\n456\n",
+      base: base_10,
+      expected_program_output: Ok(456),
+      expected_python_output: Ok("456"),
+    ),
+    // Unicode cases
+    IntegerTestData(
+      input: whitespace.horizontal_tab.character
+        <> "789"
+        <> whitespace.horizontal_tab.character,
+      base: base_10,
+      expected_program_output: Ok(789),
+      expected_python_output: Ok("789"),
+    ),
+    IntegerTestData(
+      input: whitespace.line_feed.character
+        <> "123"
+        <> whitespace.line_feed.character,
+      base: base_10,
+      expected_program_output: Ok(123),
+      expected_python_output: Ok("123"),
+    ),
+    IntegerTestData(
+      input: whitespace.vertical_tab.character
+        <> "234"
+        <> whitespace.vertical_tab.character,
+      base: base_10,
+      expected_program_output: Ok(234),
+      expected_python_output: Ok("234"),
+    ),
+    IntegerTestData(
+      input: whitespace.form_feed.character
+        <> "345"
+        <> whitespace.form_feed.character,
+      base: base_10,
+      expected_program_output: Ok(345),
+      expected_python_output: Ok("345"),
+    ),
+    IntegerTestData(
+      input: whitespace.carriage_return.character
+        <> "567"
+        <> whitespace.carriage_return.character,
+      base: base_10,
+      expected_program_output: Ok(567),
+      expected_python_output: Ok("567"),
+    ),
+    IntegerTestData(
+      input: whitespace.space.character <> "678" <> whitespace.space.character,
+      base: base_10,
+      expected_program_output: Ok(678),
+      expected_python_output: Ok("678"),
+    ),
+    IntegerTestData(
+      input: whitespace.next_line.character
+        <> "890"
+        <> whitespace.next_line.character,
+      base: base_10,
+      expected_program_output: Ok(890),
+      expected_python_output: Ok("890"),
+    ),
+    IntegerTestData(
+      input: whitespace.no_break_space.character
+        <> "901"
+        <> whitespace.no_break_space.character,
+      base: base_10,
+      expected_program_output: Ok(901),
+      expected_python_output: Ok("901"),
+    ),
+    IntegerTestData(
+      input: whitespace.ogham_space_mark.character
+        <> "012"
+        <> whitespace.ogham_space_mark.character,
+      base: base_10,
+      expected_program_output: Ok(12),
+      expected_python_output: Ok("12"),
+    ),
+    IntegerTestData(
+      input: whitespace.en_quad.character
+        <> "123"
+        <> whitespace.en_quad.character,
+      base: base_10,
+      expected_program_output: Ok(123),
+      expected_python_output: Ok("123"),
+    ),
+    IntegerTestData(
+      input: whitespace.em_quad.character
+        <> "234"
+        <> whitespace.em_quad.character,
+      base: base_10,
+      expected_program_output: Ok(234),
+      expected_python_output: Ok("234"),
+    ),
+    IntegerTestData(
+      input: whitespace.en_space.character
+        <> "345"
+        <> whitespace.en_space.character,
+      base: base_10,
+      expected_program_output: Ok(345),
+      expected_python_output: Ok("345"),
+    ),
+    IntegerTestData(
+      input: whitespace.em_space.character
+        <> "567"
+        <> whitespace.em_space.character,
+      base: base_10,
+      expected_program_output: Ok(567),
+      expected_python_output: Ok("567"),
+    ),
+    IntegerTestData(
+      input: whitespace.three_per_em_space.character
+        <> "678"
+        <> whitespace.three_per_em_space.character,
+      base: base_10,
+      expected_program_output: Ok(678),
+      expected_python_output: Ok("678"),
+    ),
+    IntegerTestData(
+      input: whitespace.four_per_em_space.character
+        <> "789"
+        <> whitespace.four_per_em_space.character,
+      base: base_10,
+      expected_program_output: Ok(789),
+      expected_python_output: Ok("789"),
+    ),
+    IntegerTestData(
+      input: whitespace.six_per_em_space.character
+        <> "890"
+        <> whitespace.six_per_em_space.character,
+      base: base_10,
+      expected_program_output: Ok(890),
+      expected_python_output: Ok("890"),
+    ),
+    IntegerTestData(
+      input: whitespace.figure_space.character
+        <> "901"
+        <> whitespace.figure_space.character,
+      base: base_10,
+      expected_program_output: Ok(901),
+      expected_python_output: Ok("901"),
+    ),
+    IntegerTestData(
+      input: whitespace.punctuation_space.character
+        <> "012"
+        <> whitespace.punctuation_space.character,
+      base: base_10,
+      expected_program_output: Ok(12),
+      expected_python_output: Ok("12"),
+    ),
+    IntegerTestData(
+      input: whitespace.thin_space.character
+        <> "123"
+        <> whitespace.thin_space.character,
+      base: base_10,
+      expected_program_output: Ok(123),
+      expected_python_output: Ok("123"),
+    ),
+    IntegerTestData(
+      input: whitespace.hair_space.character
+        <> "234"
+        <> whitespace.hair_space.character,
+      base: base_10,
+      expected_program_output: Ok(234),
+      expected_python_output: Ok("234"),
+    ),
+    IntegerTestData(
+      input: whitespace.line_separator.character
+        <> "345"
+        <> whitespace.line_separator.character,
+      base: base_10,
+      expected_program_output: Ok(345),
+      expected_python_output: Ok("345"),
+    ),
+    IntegerTestData(
+      input: whitespace.paragraph_separator.character
+        <> "567"
+        <> whitespace.paragraph_separator.character,
+      base: base_10,
+      expected_program_output: Ok(567),
+      expected_python_output: Ok("567"),
+    ),
+    IntegerTestData(
+      input: whitespace.narrow_no_break_space.character
+        <> "678"
+        <> whitespace.narrow_no_break_space.character,
+      base: base_10,
+      expected_program_output: Ok(678),
+      expected_python_output: Ok("678"),
+    ),
+    IntegerTestData(
+      input: whitespace.medium_mathematical_space.character
+        <> "789"
+        <> whitespace.medium_mathematical_space.character,
+      base: base_10,
+      expected_program_output: Ok(789),
+      expected_python_output: Ok("789"),
+    ),
+    IntegerTestData(
+      input: whitespace.ideographic_space.character
+        <> "890"
+        <> whitespace.ideographic_space.character,
+      base: base_10,
+      expected_program_output: Ok(890),
+      expected_python_output: Ok("890"),
+    ),
+    IntegerTestData(
+      input: whitespace.windows_newline.character
+        <> "123"
+        <> whitespace.windows_newline.character,
+      base: base_10,
+      expected_program_output: Ok(123),
+      expected_python_output: Ok("123"),
+    ),
+    IntegerTestData(
+      input: all_whitespace_characters_string
+        <> "666"
+        <> all_whitespace_characters_string,
+      base: base_10,
+      expected_program_output: Ok(666),
+      expected_python_output: Ok("666"),
+    ),
+  ]
+}
 
 pub fn data() -> List(IntegerTestData) {
   [
-    valid_simple,
-    valid_simple_base_2,
-    valid_simple_base_8,
-    valid_simple_base_16,
-    valid_underscore,
-    valid_whitespace,
-    valid_simple_base_prefix,
+    valid_simple(),
+    valid_simple_base_2(),
+    valid_simple_base_8(),
+    valid_simple_base_16(),
+    valid_underscore(),
+    valid_whitespace(),
+    valid_simple_base_prefix(),
   ]
   |> list.flatten
 }

--- a/test/helpers.gleam
+++ b/test/helpers.gleam
@@ -5,27 +5,30 @@ import lenient_parse/internal/whitespace.{type WhitespaceData}
 pub fn to_printable_text(text: String) -> String {
   do_to_printable_text(
     characters: text |> string.to_graphemes,
-    whitespace_strings_dict: whitespace.character_dict(),
+    whitespace_character_dict: whitespace.character_dict(),
     acc: "",
   )
 }
 
 fn do_to_printable_text(
   characters characters: List(String),
-  whitespace_strings_dict whitespace_strings_dict: Dict(String, WhitespaceData),
+  whitespace_character_dict whitespace_character_dict: Dict(
+    String,
+    WhitespaceData,
+  ),
   acc acc: String,
 ) -> String {
   case characters {
     [] -> acc
     [first, ..rest] -> {
-      let printable = case whitespace_strings_dict |> dict.get(first) {
+      let printable = case whitespace_character_dict |> dict.get(first) {
         Ok(whitespace_data) -> whitespace_data.printable
         Error(_) -> first
       }
 
       do_to_printable_text(
         characters: rest,
-        whitespace_strings_dict: whitespace_strings_dict,
+        whitespace_character_dict: whitespace_character_dict,
         acc: acc <> printable,
       )
     }

--- a/test/helpers.gleam
+++ b/test/helpers.gleam
@@ -1,34 +1,31 @@
+import gleam/dict.{type Dict}
 import gleam/string
+import lenient_parse/internal/whitespace.{type WhitespaceData}
 
-pub fn to_printable_text(text: String, python_output: Bool) -> String {
+pub fn to_printable_text(text: String) -> String {
   do_to_printable_text(
     characters: text |> string.to_graphemes,
-    python_output: python_output,
+    whitespace_strings_dict: whitespace.character_dict(),
     acc: "",
   )
 }
 
 fn do_to_printable_text(
   characters characters: List(String),
-  python_output python_output: Bool,
+  whitespace_strings_dict whitespace_strings_dict: Dict(String, WhitespaceData),
   acc acc: String,
 ) -> String {
   case characters {
     [] -> acc
     [first, ..rest] -> {
-      let printable = case first {
-        "\t" -> "\\t"
-        "\n" -> "\\n"
-        "\r" -> "\\r"
-        // Python weirdly converts "\f" to "\x0c"
-        "\f" if python_output -> "\\x0c"
-        "\f" -> "\\f"
-        "\r\n" -> "\\r\\n"
-        _ -> first
+      let printable = case whitespace_strings_dict |> dict.get(first) {
+        Ok(whitespace_data) -> whitespace_data.printable
+        Error(_) -> first
       }
+
       do_to_printable_text(
         characters: rest,
-        python_output: python_output,
+        whitespace_strings_dict: whitespace_strings_dict,
         acc: acc <> printable,
       )
     }

--- a/test/helpers_test.gleam
+++ b/test/helpers_test.gleam
@@ -1,35 +1,32 @@
+import gleam/dict
 import gleam/list
-import helpers.{to_printable_text}
+import helpers
+import lenient_parse/internal/whitespace
 import startest.{describe, it}
 import startest/expect
 
 pub fn to_printable_text_tests() {
-  describe("should_be_printable_text", [
-    describe(
-      "normal_printable",
-      [
-        #("\t", "\\t"),
-        #("\n", "\\n"),
-        #("\r", "\\r"),
-        #("\f", "\\f"),
-        #("\r\n", "\\r\\n"),
-        #("\t\nabc123\r", "\\t\\nabc123\\r"),
-        #("abc123\r\n", "abc123\\r\\n"),
-      ]
-        |> list.map(fn(tuple) {
-          let #(input, output) = tuple
-          use <- it("\"" <> output <> "\"")
-          input |> to_printable_text(False) |> expect.to_equal(output)
-        }),
-    ),
-    describe(
-      "python_printable",
-      [#("\f", "\\x0c"), #("\n\f\t", "\\n\\x0c\\t")]
-        |> list.map(fn(tuple) {
-          let #(input, output) = tuple
-          use <- it("\"" <> output <> "\"")
-          input |> to_printable_text(True) |> expect.to_equal(output)
-        }),
-    ),
-  ])
+  let whitespace_tuples =
+    whitespace.character_dict()
+    |> dict.to_list
+    |> list.map(fn(a) { #({ a.1 }.character, { a.1 }.printable) })
+
+  describe(
+    "should_be_printable_text",
+    [
+      #("\t", "\\t"),
+      #("\n", "\\n"),
+      #("\r", "\\r"),
+      #("\f", "\\x0c"),
+      #("\r\n", "\\r\\n"),
+      #("\t\nabc123\r", "\\t\\nabc123\\r"),
+      #("abc123\r\n", "abc123\\r\\n"),
+    ]
+      |> list.append(whitespace_tuples)
+      |> list.map(fn(tuple) {
+        let #(input, output) = tuple
+        use <- it("\"" <> output <> "\"")
+        input |> helpers.to_printable_text |> expect.to_equal(output)
+      }),
+  )
 }

--- a/test/python_parse_test.gleam
+++ b/test/python_parse_test.gleam
@@ -18,7 +18,7 @@ pub fn check_against_python_tests() {
           let expected_python_output = { data.0 }.expected_python_output
           let actual_python_output = data.1
 
-          let input_printable_text = input |> helpers.to_printable_text(False)
+          let input_printable_text = input |> helpers.to_printable_text
 
           let message = case expected_program_output, expected_python_output {
             Ok(_), Ok(python_output) -> {
@@ -67,7 +67,7 @@ pub fn check_against_python_tests() {
           let expected_python_output = { data.0 }.expected_python_output
           let actual_python_output = data.1
 
-          let input_printable_text = input |> helpers.to_printable_text(False)
+          let input_printable_text = input |> helpers.to_printable_text
 
           let base_text = case base {
             10 -> ""

--- a/test/to_float_parse_test.gleam
+++ b/test/to_float_parse_test.gleam
@@ -13,7 +13,7 @@ pub fn to_float_tests() {
     data.float_test_data()
       |> list.map(fn(data) {
         let input = data.input
-        let input_printable_text = input |> helpers.to_printable_text(False)
+        let input_printable_text = input |> helpers.to_printable_text
         let expected_program_output = data.expected_program_output
 
         let message = case expected_program_output {

--- a/test/to_int_parse_test.gleam
+++ b/test/to_int_parse_test.gleam
@@ -13,7 +13,7 @@ pub fn to_int_tests() {
     data.integer_test_data()
       |> list.map(fn(data) {
         let input = data.input
-        let input_printable_text = input |> helpers.to_printable_text(False)
+        let input_printable_text = input |> helpers.to_printable_text
         let expected_program_output = data.expected_program_output
         let base = data.base
 

--- a/test/tokenizer_test.gleam
+++ b/test/tokenizer_test.gleam
@@ -1,3 +1,10 @@
+import gleam/dict
+import gleam/list
+import gleam/string
+import lenient_parse/internal/whitespace.{
+  carriage_return, form_feed, horizontal_tab, line_feed, space, windows_newline,
+}
+
 import lenient_parse/internal/base_constants.{
   base_0, base_10, base_16, base_2, base_8,
 }
@@ -14,12 +21,12 @@ pub fn tokenize_float_test() {
   " \t\n\r\f\r\n+-0123456789eE._abc"
   |> tokenizer.tokenize_float
   |> expect.to_equal([
-    Whitespace(#(0, 1), " "),
-    Whitespace(#(1, 2), "\t"),
-    Whitespace(#(2, 3), "\n"),
-    Whitespace(#(3, 4), "\r"),
-    Whitespace(#(4, 5), "\f"),
-    Whitespace(#(5, 6), "\r\n"),
+    Whitespace(#(0, 1), space),
+    Whitespace(#(1, 2), horizontal_tab),
+    Whitespace(#(2, 3), line_feed),
+    Whitespace(#(3, 4), carriage_return),
+    Whitespace(#(4, 5), form_feed),
+    Whitespace(#(5, 6), windows_newline),
     Sign(#(6, 7), "+", True),
     Sign(#(7, 8), "-", False),
     Digit(#(8, 9), "0", 0),
@@ -48,12 +55,12 @@ pub fn tokenize_int_base_10_test() {
   " \t\n\r\f\r\n+-0123456789eE._abcZ"
   |> tokenizer.tokenize_int(base: base_10)
   |> expect.to_equal([
-    Whitespace(#(0, 1), " "),
-    Whitespace(#(1, 2), "\t"),
-    Whitespace(#(2, 3), "\n"),
-    Whitespace(#(3, 4), "\r"),
-    Whitespace(#(4, 5), "\f"),
-    Whitespace(#(5, 6), "\r\n"),
+    Whitespace(#(0, 1), space),
+    Whitespace(#(1, 2), horizontal_tab),
+    Whitespace(#(2, 3), line_feed),
+    Whitespace(#(3, 4), carriage_return),
+    Whitespace(#(4, 5), form_feed),
+    Whitespace(#(5, 6), windows_newline),
     Sign(#(6, 7), "+", True),
     Sign(#(7, 8), "-", False),
     Digit(#(8, 9), "0", 0),
@@ -167,9 +174,9 @@ pub fn tokenize_int_with_0b_prefix_and_base_0_test() {
   "   0b1010b"
   |> tokenizer.tokenize_int(base: base_0)
   |> expect.to_equal([
-    Whitespace(#(0, 1), " "),
-    Whitespace(#(1, 2), " "),
-    Whitespace(#(2, 3), " "),
+    Whitespace(#(0, 1), space),
+    Whitespace(#(1, 2), space),
+    Whitespace(#(2, 3), space),
     BasePrefix(#(3, 5), "0b", base_2),
     Digit(#(5, 6), "1", 1),
     Digit(#(6, 7), "0", 0),
@@ -183,9 +190,9 @@ pub fn tokenize_int_with_0o_prefix_and_base_0_test() {
   "   0o0123456780o"
   |> tokenizer.tokenize_int(base: base_0)
   |> expect.to_equal([
-    Whitespace(#(0, 1), " "),
-    Whitespace(#(1, 2), " "),
-    Whitespace(#(2, 3), " "),
+    Whitespace(#(0, 1), space),
+    Whitespace(#(1, 2), space),
+    Whitespace(#(2, 3), space),
     BasePrefix(#(3, 5), "0o", base_8),
     Digit(#(5, 6), "0", 0),
     Digit(#(6, 7), "1", 1),
@@ -205,7 +212,7 @@ pub fn tokenize_int_with_0x_prefix_and_base_0_test() {
   " +0XDEAD_BEEF0x "
   |> tokenizer.tokenize_int(base: base_0)
   |> expect.to_equal([
-    Whitespace(#(0, 1), " "),
+    Whitespace(#(0, 1), space),
     Sign(#(1, 2), "+", True),
     BasePrefix(#(2, 4), "0X", base_16),
     Digit(#(4, 5), "D", 13),
@@ -219,7 +226,7 @@ pub fn tokenize_int_with_0x_prefix_and_base_0_test() {
     Digit(#(12, 13), "F", 15),
     Digit(#(13, 14), "0", 0),
     Digit(#(14, 15), "x", 33),
-    Whitespace(#(15, 16), " "),
+    Whitespace(#(15, 16), space),
   ])
 }
 
@@ -227,15 +234,15 @@ pub fn tokenize_int_with_0b_prefix_and_base_2_test() {
   "   0b1010 a"
   |> tokenizer.tokenize_int(base: base_2)
   |> expect.to_equal([
-    Whitespace(#(0, 1), " "),
-    Whitespace(#(1, 2), " "),
-    Whitespace(#(2, 3), " "),
+    Whitespace(#(0, 1), space),
+    Whitespace(#(1, 2), space),
+    Whitespace(#(2, 3), space),
     BasePrefix(#(3, 5), "0b", base_2),
     Digit(#(5, 6), "1", 1),
     Digit(#(6, 7), "0", 0),
     Digit(#(7, 8), "1", 1),
     Digit(#(8, 9), "0", 0),
-    Whitespace(#(9, 10), " "),
+    Whitespace(#(9, 10), space),
     Digit(#(10, 11), "a", 10),
   ])
 }
@@ -244,13 +251,13 @@ pub fn tokenize_int_with_0o_prefix_and_base_8_test() {
   "   0o77 a"
   |> tokenizer.tokenize_int(base: base_8)
   |> expect.to_equal([
-    Whitespace(#(0, 1), " "),
-    Whitespace(#(1, 2), " "),
-    Whitespace(#(2, 3), " "),
+    Whitespace(#(0, 1), space),
+    Whitespace(#(1, 2), space),
+    Whitespace(#(2, 3), space),
     BasePrefix(#(3, 5), "0o", base_8),
     Digit(#(5, 6), "7", 7),
     Digit(#(6, 7), "7", 7),
-    Whitespace(#(7, 8), " "),
+    Whitespace(#(7, 8), space),
     Digit(#(8, 9), "a", 10),
   ])
 }
@@ -259,15 +266,15 @@ pub fn tokenize_int_with_0x_prefix_and_base_16_test() {
   "   0x_ABC ."
   |> tokenizer.tokenize_int(base: base_16)
   |> expect.to_equal([
-    Whitespace(#(0, 1), " "),
-    Whitespace(#(1, 2), " "),
-    Whitespace(#(2, 3), " "),
+    Whitespace(#(0, 1), space),
+    Whitespace(#(1, 2), space),
+    Whitespace(#(2, 3), space),
     BasePrefix(#(3, 5), "0x", base_16),
     Underscore(#(5, 6)),
     Digit(#(6, 7), "A", 10),
     Digit(#(7, 8), "B", 11),
     Digit(#(8, 9), "C", 12),
-    Whitespace(#(9, 10), " "),
+    Whitespace(#(9, 10), space),
     Unknown(#(10, 11), "."),
   ])
 }
@@ -344,9 +351,9 @@ pub fn tokenize_int_with_no_prefix_and_base_0_test() {
   "  \n+1990_04_12.0e4 "
   |> tokenizer.tokenize_int(base: base_0)
   |> expect.to_equal([
-    Whitespace(#(0, 1), " "),
-    Whitespace(#(1, 2), " "),
-    Whitespace(#(2, 3), "\n"),
+    Whitespace(#(0, 1), space),
+    Whitespace(#(1, 2), space),
+    Whitespace(#(2, 3), line_feed),
     Sign(#(3, 4), "+", True),
     Digit(#(4, 5), "1", 1),
     Digit(#(5, 6), "9", 9),
@@ -362,7 +369,7 @@ pub fn tokenize_int_with_no_prefix_and_base_0_test() {
     Digit(#(15, 16), "0", 0),
     Digit(#(16, 17), "e", 14),
     Digit(#(17, 18), "4", 4),
-    Whitespace(#(18, 19), " "),
+    Whitespace(#(18, 19), space),
   ])
 }
 
@@ -399,4 +406,23 @@ pub fn tokenize_int_with_base_16_and_hexadecimal_prefix_test() {
     Digit(#(3, 4), "B", 11),
     Digit(#(4, 5), "C", 12),
   ])
+}
+
+// ---- Tests for all whitespace characters
+
+pub fn tokenize_int_with_all_whitespace_characters_test() {
+  let whitespace_character_strings = whitespace.character_dict() |> dict.to_list
+
+  let expected_tokens =
+    whitespace_character_strings
+    |> list.index_map(fn(whitespace_data, index) {
+      Whitespace(#(index, index + 1), data: whitespace_data.1)
+    })
+
+  let whitespace_character_strings = whitespace.character_dict() |> dict.keys()
+
+  whitespace_character_strings
+  |> string.join("")
+  |> tokenizer.tokenize_int(base: base_10)
+  |> expect.to_equal(expected_tokens)
 }


### PR DESCRIPTION
We now handle a whole slew of weird whitespace characters accepted by Python. Some examples:

```gleam
pub const em_quad = WhitespaceData(
  character: "\u{2001}",
  printable: "\\u2001",
  codepoint_values: [0x2001],
)

pub const en_space = WhitespaceData(
  character: "\u{2002}",
  printable: "\\u2002",
  codepoint_values: [0x2002],
)

pub const em_space = WhitespaceData(
  character: "\u{2003}",
  printable: "\\u2003",
  codepoint_values: [0x2003],
)
```

These are tokenized as whitespace, and so the same rules apply. Leading and trailing whitespace is acceptable, whitespace in the middle is not.